### PR TITLE
Docs: point agent skills at bigbio/sdrf-annotated-datasets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ All 14 skills are user-invocable. Type `/sdrf:` and autocomplete will show them 
 | `/sdrf:explain` | Explain any SDRF column, error, or concept in plain language |
 | `/sdrf:convert` | Pipeline selection (MaxQuant, DIA-NN, OpenMS, quantms) + conversion commands |
 | `/sdrf:design` | Experimental design: batch effects, confounders, replication, MSstats contrasts |
-| `/sdrf:contribute` | Contribute annotated SDRF back to proteomics-sample-metadata via PR (automated or guided) |
+| `/sdrf:contribute` | Contribute annotated SDRF back to sdrf-annotated-datasets via PR (automated or guided) |
 | `/sdrf:techrefine` | Verify/refine technical metadata (instrument, tolerances, mods, DDA/DIA) from raw files via techsdrf |
 
 ## MCP Servers Used

--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ Claude:
 You: /sdrf:contribute PXD045678
 
 Claude:
-  → Checks if PXD045678 already exists in annotated-projects/
+  → Checks if PXD045678 already exists in datasets/
   → Validates the SDRF file
-  → Forks bigbio/proteomics-sample-metadata
+  → Forks bigbio/sdrf-annotated-datasets
   → Creates branch annotation/PXD045678
-  → Commits the SDRF file to annotated-projects/PXD045678/
+  → Commits the SDRF file to datasets/PXD045678/
   → Opens a PR with dataset summary (organism, templates, row count)
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All 15 skills are under the `sdrf:` namespace. In Claude Code, type `/sdrf:` and
 | `/sdrf:explain` | Explain any column, error, or concept in plain language |
 | `/sdrf:convert` | Choose and configure analysis pipelines from SDRF |
 | `/sdrf:design` | Detect batch effects, confounders, replication issues |
-| `/sdrf:contribute` | Contribute annotated SDRF back to community via PR |
+| `/sdrf:contribute` | Contribute annotated SDRF back to sdrf-annotated-datasets via PR |
 | `/sdrf:techrefine` | Verify/refine technical metadata from raw files via techsdrf |
 
 ## Installation

--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -263,13 +263,13 @@ Present the validated SDRF as a TSV code block and explain:
 
 If the annotation was for a **ProteomeXchange dataset** (PXD accession):
 
-1. Check if this PXD already exists in `spec/annotated-projects/{PXD}/`
+1. Check if this PXD already exists in `bigbio/sdrf-annotated-datasets` under `datasets/{PXD}/`
 2. Tell the user their annotation can be contributed to the community:
 
 ```text
 Your SDRF annotation for {PXD} is ready!
 
-The proteomics-sample-metadata community repository collects annotated SDRF files
+The sdrf-annotated-datasets community repository collects annotated SDRF files
 for ProteomeXchange datasets. Contributing your annotation means:
   - Other researchers can reuse your metadata
   - Analysis pipelines (quantms) can automatically reprocess the dataset
@@ -278,7 +278,7 @@ for ProteomeXchange datasets. Contributing your annotation means:
 Run /sdrf:contribute {PXD} to create a PR, or see the commands to do it manually.
 ```
 
-3. If the PXD already exists in annotated-projects/, mention this is an update to an existing annotation
+3. If the PXD already exists in `datasets/`, mention this is an update to an existing annotation
 
 This step is a recommendation only — do not force the user to contribute.
 

--- a/skills/sdrf-contribute/SKILL.md
+++ b/skills/sdrf-contribute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdrf:contribute
-description: Use when the user has a completed SDRF annotation for a ProteomeXchange dataset and wants to contribute it back to the community via a PR to proteomics-sample-metadata.
+description: Use when the user has a completed SDRF annotation for a ProteomeXchange dataset and wants to contribute it back to the community via a PR to sdrf-annotated-datasets.
 user-invocable: true
 argument-hint: "[PXD accession and SDRF file path]"
 ---
@@ -8,7 +8,7 @@ argument-hint: "[PXD accession and SDRF file path]"
 # SDRF Contribution Workflow
 
 You are helping the user contribute an annotated SDRF file back to the community repository
-(`bigbio/proteomics-sample-metadata`). This is the final step after annotation, validation,
+(`bigbio/sdrf-annotated-datasets`). This is the final step after annotation, validation,
 and review — closing the loop from "I annotated a dataset" to "the community can reuse it."
 
 ## Step 1: Check Prerequisites
@@ -23,9 +23,16 @@ and review — closing the loop from "I annotated a dataset" to "the community c
 - Ask the user to confirm the file path or provide the content
 
 ### 1.3 Check if this is a new annotation or an update
-Check if the PXD already exists in the community repository:
+Check if the PXD already exists in the community repository
+(`bigbio/sdrf-annotated-datasets`):
 ```text
-Look for: spec/annotated-projects/{PXD}/{PXD}.sdrf.tsv
+Look for: datasets/{PXD}/{PXD}.sdrf.tsv
+```
+
+You can check via the GitHub API without cloning:
+```bash
+gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD} \
+  --silent && echo "exists" || echo "new"
 ```
 
 - **New annotation**: The PXD folder does not exist → this is a new contribution
@@ -56,16 +63,16 @@ Warnings are acceptable — mention them but allow the user to proceed.
 ## Step 3: Prepare the File
 
 ### 3.1 File naming convention
-The community repository uses this structure:
+The community repository (`bigbio/sdrf-annotated-datasets`) uses this structure:
 ```text
-annotated-projects/
+datasets/
 └── {PXD}/
     └── {PXD}.sdrf.tsv
 ```
 
 For datasets with multiple sub-experiments:
 ```text
-annotated-projects/
+datasets/
 └── {PXD}/
     ├── {PXD}-celllines.sdrf.tsv
     └── {PXD}-tissues.sdrf.tsv
@@ -93,32 +100,29 @@ Execute the full contribution flow:
 
 ```bash
 # 1. Fork the repository (if not already forked)
-gh repo fork bigbio/proteomics-sample-metadata --clone=false
+gh repo fork bigbio/sdrf-annotated-datasets --clone=false
 
 # 2. Clone the user's fork
-gh repo clone {username}/proteomics-sample-metadata /tmp/proteomics-sample-metadata
-cd /tmp/proteomics-sample-metadata
+gh repo clone {username}/sdrf-annotated-datasets /tmp/sdrf-annotated-datasets
+cd /tmp/sdrf-annotated-datasets
 
-# 3. Initialize submodules
-git submodule update --init --recursive
-
-# 4. Create a branch
+# 3. Create a branch
 git checkout -b annotation/{PXD}
 
-# 5. Create the directory and copy the file
-mkdir -p annotated-projects/{PXD}
-cp {source_path}/{PXD}.sdrf.tsv annotated-projects/{PXD}/
+# 4. Create the directory and copy the file
+mkdir -p datasets/{PXD}
+cp {source_path}/{PXD}.sdrf.tsv datasets/{PXD}/
 
-# 6. Commit
-git add annotated-projects/{PXD}/
+# 5. Commit
+git add datasets/{PXD}/
 git commit -m "Add SDRF annotation for {PXD}"
 
-# 7. Push
+# 6. Push
 git push -u origin annotation/{PXD}
 
-# 8. Create the PR
+# 7. Create the PR
 gh pr create \
-  --repo bigbio/proteomics-sample-metadata \
+  --repo bigbio/sdrf-annotated-datasets \
   --title "Add SDRF annotation for {PXD}" \
   --body "$(cat <<'EOF'
 ## Add SDRF annotation for {PXD}

--- a/skills/sdrf-fix/SKILL.md
+++ b/skills/sdrf-fix/SKILL.md
@@ -174,7 +174,7 @@ Present the re-validation summary alongside the changelog.
 
 If all errors are fixed and the SDRF is for a ProteomeXchange dataset (PXD accession),
 suggest contributing the corrected annotation via `/sdrf:contribute {PXD}` to the
-`proteomics-sample-metadata` community repository.
+`sdrf-annotated-datasets` community repository.
 
 ## When NOT to Auto-Fix
 

--- a/skills/sdrf-review/SKILL.md
+++ b/skills/sdrf-review/SKILL.md
@@ -127,4 +127,4 @@ Provide clear next steps:
 4. Suggest running final validation after fixes
 5. If the SDRF is for a ProteomeXchange dataset and the verdict is VALID or NEEDS MINOR FIXES:
    suggest contributing the annotation via `/sdrf:contribute {PXD}` to the
-   `proteomics-sample-metadata` community repository
+   `sdrf-annotated-datasets` community repository

--- a/skills/sdrf-review/SKILL.md
+++ b/skills/sdrf-review/SKILL.md
@@ -128,3 +128,4 @@ Provide clear next steps:
 5. If the SDRF is for a ProteomeXchange dataset and the verdict is VALID or NEEDS MINOR FIXES:
    suggest contributing the annotation via `/sdrf:contribute {PXD}` to the
    `sdrf-annotated-datasets` community repository
+


### PR DESCRIPTION
## Summary
- annotated SDRFs moved from `bigbio/proteomics-sample-metadata/annotated-projects/` to `bigbio/sdrf-annotated-datasets/datasets/{PXD}/`
- update the contribution-oriented skill references (fork target, file-layout diagrams, existence check, PR target) so agents write to the new repo
- the `spec/` submodule is left alone; it tracks the specification repo and its own PR (#819 there) updates the spec docs

## Files touched
- `CLAUDE.md` — `/sdrf:contribute` one-liner
- `README.md` — `/sdrf:contribute` narrative example
- `skills/sdrf-annotate/SKILL.md` — existence check + recommendation copy
- `skills/sdrf-contribute/SKILL.md` — YAML description, intro, existence check (now via `gh api`), file-layout diagrams, full Mode A command sequence
- `skills/sdrf-fix/SKILL.md`, `skills/sdrf-review/SKILL.md` — repo-name mention

## Related
- New repo: https://github.com/bigbio/sdrf-annotated-datasets
- Source spec repo PR: https://github.com/bigbio/proteomics-sample-metadata/pull/819
- sdrfedit PR: https://github.com/bigbio/sdrfedit/pull/20
- Migration discussion: https://github.com/bigbio/proteomics-sample-metadata/issues/817

## Test plan
- [ ] `grep -R annotated-projects . --exclude-dir=spec --exclude-dir=quantms-datasets` returns nothing
- [ ] `gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/PXD000070 --silent` (existence check) succeeds
- [ ] Running `/sdrf:contribute` on a fresh PXD opens a PR against `bigbio/sdrf-annotated-datasets` with files under `datasets/{PXD}/`