### PR TITLE
docs: add Asier Larrea Sebal as a contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,11 @@ To add a new skill:
 
 Maintained by the [BigBio](https://github.com/bigbio) team.
 
-- **Yasset Perez-Riverol** — [@ypriverol](https://github.com/ypriverol) · [ypriverol@gmail.com](mailto:ypriverol@gmail.com) · [@ypriverol](https://twitter.com/ypriverol)
+- **Yasset Perez-Riverol** (maintainer) — [@ypriverol](https://github.com/ypriverol) · [ypriverol@gmail.com](mailto:ypriverol@gmail.com) · [@ypriverol](https://twitter.com/ypriverol)
+
+### Contributors
+
+- **Asier Larrea Sebal** — [@asierlarrea](https://github.com/asierlarrea) · EMBL-EBI
 
 For questions about the SDRF specification itself, open an issue in
 [bigbio/proteomics-metadata-standard](https://github.com/bigbio/proteomics-metadata-standard).


### PR DESCRIPTION
## Summary

Adds **Asier Larrea Sebal** ([@asierlarrea](https://github.com/asierlarrea), EMBL-EBI) as a contributor in the README. Introduces a `### Contributors` subsection under `## Contact` to keep the maintainer line distinct from contributor recognition.

Recognises Asier's work merged via #7 (Olink handling + spec-driven `improve`).

## Notes

- Listed only GitHub handle and affiliation. Happy to add email / X handle if Asier wants them included — let me know.
- The `cell-lines` template in the spec already credits him with his EBI email; I deliberately did not duplicate that here without explicit confirmation.

## Test plan

- [ ] README renders the new "Contributors" subsection correctly on GitHub
- [ ] @asierlarrea sign-off on the listing

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7WYH8tPpyefR5JDLPSuww)_