### PR TITLE
Add MassIVE raw-file helper and conservative demographic rules

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -26,11 +26,12 @@ cp -r spec/ ~/.agents/skills/sdrf-skills/spec/
 
 ## What it provides
 
-15 structured workflows (SKILL.md files) that encode expert-level SDRF annotation methodology:
+16 structured workflows (SKILL.md files) that encode expert-level SDRF annotation methodology:
 
 | Skill | Purpose |
 |-------|---------|
 | sdrf-setup | Install dependencies (parse_sdrf, techsdrf) — conda or pip setup |
+| sdrf-autoresearch | Autonomous retained-improvement loop over one dataset, a manifest, or a dataset class |
 | sdrf-knowledge | SDRF format rules, column names, ontology mappings |
 | sdrf-templates | Template system, layer selection, mutual exclusivity |
 | sdrf-annotate | Full annotation: PXD → PRIDE + paper → draft SDRF |
@@ -52,6 +53,12 @@ Each SKILL.md file contains a complete workflow. Reference them from your Codex 
 
 ```text
 When annotating SDRF files, follow the workflow in skills/sdrf-annotate/SKILL.md
+```
+
+For autonomous loops, reference:
+
+```text
+Use the workflow in skills/sdrf-autoresearch/SKILL.md with target, profile, objective, evidence, stop, and write settings.
 ```
 
 ## Prerequisites

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ SDRF (Sample and Data Relationship Format) annotation in proteomics.
 
 ## What This Does
 
-14 structured workflows (SKILL.md files) that guide AI assistants through SDRF tasks
+16 structured workflows (SKILL.md files) that guide AI assistants through SDRF tasks
 using existing MCP tools (OLS, PRIDE, PubMed, bioRxiv, EuropePMC).
 Instead of guessing at ontology terms or validation rules, skills encode the
 community's annotation expertise as repeatable methodology.
@@ -27,6 +27,7 @@ All 16 skills are user-invocable. Type `/sdrf:` and autocomplete will show them 
 | Command | Purpose |
 |---------|---------|
 | `/sdrf:setup` | Install dependencies (parse_sdrf, techsdrf) — conda or pip guided setup |
+| `/sdrf:autoresearch` | Autonomous retained-improvement loop over one dataset, a manifest, or a dataset class |
 | `/sdrf:knowledge` | SDRF format rules, column definitions (from TERMS.tsv), ontology routing, modification format, reserved words |
 | `/sdrf:templates` | Template system (from templates.yaml), selection rules, mutual exclusivity, inheritance |
 | `/sdrf:annotate` | Full annotation: PXD → PRIDE + paper → select templates → draft SDRF → validate |
@@ -64,3 +65,5 @@ These skills expect the following MCP servers to be available:
 9. Multiple `comment[modification parameters]` columns are normal (one per modification)
 10. Multiple `comment[sdrf template]` columns are normal (one per template)
 11. ALWAYS validate with `parse_sdrf validate-sdrf --sdrf_file X --template Y` before presenting any produced SDRF to the user — update spec first with `git submodule update --remote --recursive`
+12. When the user asks for autonomous large-scale annotation, use `/sdrf:autoresearch` to resolve the target set, choose an objective, and run retained improvement rounds until the configured stop rule fires
+13. For blood-plasma discovery or biomarker campaigns, default to `Homo sapiens` only and require manuscript-backed plasma confirmation before promoting a dataset into annotation

--- a/scripts/massive_raw_files.py
+++ b/scripts/massive_raw_files.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""
+Resolve MassIVE raw or acquisition file names for a PXD/MSV accession.
+
+This helper is intended for SDRF curation when:
+- a ProteomeXchange accession is hosted by MassIVE
+- PRIDE `/projects/{PXD}/files/all` is empty or incomplete
+- you need actual file names for `comment[data file]`
+
+Resolution chain:
+1. If the input is a PXD, query ProteomeCentral PROXI to resolve the MassIVE ID.
+2. If a MassIVE task is available, query the MassIVE detail JSON endpoint.
+3. Recursively walk the MassIVE FTP tree to list files.
+
+The script defaults to vendor raw-like files, but can also include open formats
+such as mzML/mzXML or emit every file under the dataset FTP root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ftplib
+import json
+import posixpath
+import re
+import sys
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+
+
+PX_PROXI_TEMPLATE = "https://proteomecentral.proteomexchange.org/api/proxi/v0.1/datasets/{accession}"
+MASSIVE_DETAIL_TEMPLATE = (
+    "https://massive.ucsd.edu/ProteoSAFe/MassiveServlet?task={task}&function=massiveinformation"
+)
+
+PXD_RE = re.compile(r"^PXD\d{6,}$", re.IGNORECASE)
+MSV_RE = re.compile(r"^MSV\d+(?:\.\d+)?$", re.IGNORECASE)
+TASK_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
+
+VENDOR_RAW_SUFFIXES = (
+    ".raw",
+    ".wiff",
+    ".wiff.scan",
+    ".d",
+    ".baf",
+    ".yep",
+    ".lcd",
+    ".tdf",
+    ".tsf",
+    ".fid",
+)
+OPEN_ACQUISITION_SUFFIXES = (".mzml", ".mzxml")
+
+DEFAULT_TIMEOUT = 120
+USER_AGENT = "sdrf-skills/massive-raw-files/0.1"
+
+
+@dataclass
+class MassiveResolution:
+    input_accession: str
+    pxd_accession: str | None = None
+    massive_accession: str | None = None
+    task: str | None = None
+    ftp_url: str | None = None
+    title: str | None = None
+    hosting_repository: str | None = None
+    filecount_hint: int | None = None
+    filesize_hint: str | None = None
+
+
+def fetch_json(url: str) -> object:
+    request = urllib.request.Request(url, headers={"Accept": "application/json", "User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT) as response:
+        return json.load(response)
+
+
+def normalize_accession(value: str) -> str:
+    return value.strip()
+
+
+def parse_task_from_url(url: str) -> str | None:
+    parsed = urllib.parse.urlparse(url)
+    query = urllib.parse.parse_qs(parsed.query)
+    task = query.get("task", [None])[0]
+    if task and TASK_RE.match(task):
+        return task
+    return None
+
+
+def parse_massive_from_url(url: str) -> str | None:
+    parsed = urllib.parse.urlparse(url)
+    query = urllib.parse.parse_qs(parsed.query)
+    for key in ("id", "dataset", "dataset_id"):
+        value = query.get(key, [None])[0]
+        if value and MSV_RE.match(value):
+            return value.upper()
+    match = re.search(r"(MSV\d+(?:\.\d+)?)", url, flags=re.IGNORECASE)
+    if match:
+        return match.group(1).upper()
+    return None
+
+
+def resolve_from_proteomecentral(pxd_accession: str) -> MassiveResolution:
+    payload = fetch_json(PX_PROXI_TEMPLATE.format(accession=urllib.parse.quote(pxd_accession)))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Unexpected ProteomeCentral payload for {pxd_accession}")
+
+    resolution = MassiveResolution(
+        input_accession=pxd_accession,
+        pxd_accession=pxd_accession.upper(),
+        title=payload.get("title"),
+    )
+
+    dataset_summary = payload.get("datasetSummary") or {}
+    if isinstance(dataset_summary, dict):
+        resolution.hosting_repository = dataset_summary.get("hostingRepository")
+
+    for item in payload.get("identifiers", []) or []:
+        if not isinstance(item, dict):
+            continue
+        name = (item.get("name") or "").lower()
+        value = item.get("value") or ""
+        if "massive dataset identifier" in name and value:
+            resolution.massive_accession = value.upper()
+
+    for item in payload.get("fullDatasetLinks", []) or []:
+        if not isinstance(item, dict):
+            continue
+        name = (item.get("name") or "").lower()
+        value = item.get("value") or ""
+        if not value:
+            continue
+        if "massive dataset uri" in name:
+            resolution.task = resolution.task or parse_task_from_url(value)
+            resolution.massive_accession = resolution.massive_accession or parse_massive_from_url(value)
+        elif "dataset ftp location" in name:
+            resolution.ftp_url = value
+
+    return resolution
+
+
+def enrich_from_massive_detail(resolution: MassiveResolution) -> MassiveResolution:
+    if not resolution.task:
+        return resolution
+    payload = fetch_json(MASSIVE_DETAIL_TEMPLATE.format(task=urllib.parse.quote(resolution.task)))
+    if not isinstance(payload, dict):
+        return resolution
+
+    if not resolution.massive_accession and payload.get("dataset_id"):
+        resolution.massive_accession = str(payload["dataset_id"]).upper()
+    if not resolution.pxd_accession and payload.get("pxaccession"):
+        resolution.pxd_accession = str(payload["pxaccession"]).upper()
+    if not resolution.ftp_url and payload.get("ftp"):
+        resolution.ftp_url = str(payload["ftp"])
+    if not resolution.title and payload.get("title"):
+        resolution.title = str(payload["title"])
+    filecount = payload.get("filecount")
+    if filecount not in (None, "", "null"):
+        try:
+            resolution.filecount_hint = int(str(filecount))
+        except ValueError:
+            pass
+    filesize = payload.get("filesize")
+    if filesize not in (None, "", "null"):
+        resolution.filesize_hint = str(filesize)
+    return resolution
+
+
+def ftp_candidates(resolution: MassiveResolution) -> list[str]:
+    candidates: list[str] = []
+    if resolution.ftp_url:
+        candidates.append(resolution.ftp_url)
+    if resolution.massive_accession:
+        msv = resolution.massive_accession
+        for url in (
+            f"ftp://massive-ftp.ucsd.edu/v02/{msv}/",
+            f"ftp://massive.ucsd.edu/v02/{msv}/",
+            f"ftp://massive.ucsd.edu/{msv}/",
+        ):
+            if url not in candidates:
+                candidates.append(url)
+    return candidates
+
+
+def parse_ftp_url(url: str) -> tuple[str, str]:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "ftp" or not parsed.hostname:
+        raise ValueError(f"Unsupported FTP URL: {url}")
+    path = parsed.path or "/"
+    return parsed.hostname, path
+
+
+def is_container_raw_dir(name: str) -> bool:
+    return name.lower().endswith(".d")
+
+
+def file_matches_mode(path: str, mode: str) -> bool:
+    lower = path.lower()
+    if mode == "all":
+        return True
+    if lower.endswith(VENDOR_RAW_SUFFIXES):
+        return True
+    if mode == "acquisition" and lower.endswith(OPEN_ACQUISITION_SUFFIXES):
+        return True
+    return False
+
+
+def ftp_walk_files(host: str, root_path: str, mode: str) -> list[str]:
+    ftp = ftplib.FTP(host, timeout=DEFAULT_TIMEOUT)
+    ftp.login("anonymous", "anonymous")
+    found: list[str] = []
+
+    def walk_nlst(path: str) -> None:
+        try:
+            entries = ftp.nlst(path)
+        except ftplib.error_perm:
+            return
+
+        for entry in entries:
+            normalized = entry.rstrip("/")
+            if not normalized or normalized == path.rstrip("/"):
+                continue
+            base = posixpath.basename(normalized)
+            if base in (".", ".."):
+                continue
+
+            current_dir = ftp.pwd()
+            try:
+                ftp.cwd(normalized)
+            except ftplib.error_perm:
+                if file_matches_mode(normalized, mode):
+                    found.append(normalized)
+                continue
+            else:
+                ftp.cwd(current_dir)
+                if is_container_raw_dir(base):
+                    if file_matches_mode(normalized, mode):
+                        found.append(normalized)
+                    continue
+                walk_nlst(normalized)
+
+    def walk(path: str) -> None:
+        try:
+            entries = list(ftp.mlsd(path))
+        except (ftplib.error_perm, AttributeError):
+            # Some MassIVE servers expose only NLST-style directory listings.
+            # Recurse by probing each entry with cwd() so we don't stop at the
+            # top-level folder names.
+            walk_nlst(path)
+            return
+
+        for name, facts in entries:
+            if name in (".", ".."):
+                continue
+            full_path = posixpath.join(path.rstrip("/"), name) if path != "/" else f"/{name}"
+            entry_type = (facts.get("type") or "").lower()
+            if entry_type == "dir":
+                if is_container_raw_dir(name):
+                    if file_matches_mode(full_path, mode):
+                        found.append(full_path)
+                    continue
+                walk(full_path)
+            elif entry_type == "file":
+                if file_matches_mode(full_path, mode):
+                    found.append(full_path)
+
+    try:
+        walk(root_path.rstrip("/") or "/")
+    finally:
+        try:
+            ftp.quit()
+        except Exception:
+            ftp.close()
+    return sorted(set(found))
+
+
+def resolve_accession(accession: str) -> MassiveResolution:
+    accession = normalize_accession(accession)
+    if PXD_RE.match(accession):
+        resolution = resolve_from_proteomecentral(accession.upper())
+        return enrich_from_massive_detail(resolution)
+    if MSV_RE.match(accession):
+        return MassiveResolution(input_accession=accession.upper(), massive_accession=accession.upper())
+    if TASK_RE.match(accession):
+        resolution = MassiveResolution(input_accession=accession.lower(), task=accession.lower())
+        return enrich_from_massive_detail(resolution)
+    raise SystemExit(f"Unsupported accession format: {accession}")
+
+
+def emit_text(files: list[str]) -> None:
+    for file_path in files:
+        print(file_path)
+
+
+def emit_tsv(resolution: MassiveResolution, files: list[str]) -> None:
+    print("\t".join(["input_accession", "pxd_accession", "massive_accession", "basename", "ftp_path"]))
+    for file_path in files:
+        print(
+            "\t".join(
+                [
+                    resolution.input_accession,
+                    resolution.pxd_accession or "",
+                    resolution.massive_accession or "",
+                    posixpath.basename(file_path.rstrip("/")),
+                    file_path,
+                ]
+            )
+        )
+
+
+def emit_json(resolution: MassiveResolution, ftp_url: str | None, files: list[str]) -> None:
+    payload = {
+        "input_accession": resolution.input_accession,
+        "pxd_accession": resolution.pxd_accession,
+        "massive_accession": resolution.massive_accession,
+        "task": resolution.task,
+        "title": resolution.title,
+        "hosting_repository": resolution.hosting_repository,
+        "ftp_url": ftp_url,
+        "filecount_hint": resolution.filecount_hint,
+        "filesize_hint": resolution.filesize_hint,
+        "raw_file_count": len(files),
+        "files": files,
+    }
+    json.dump(payload, sys.stdout, indent=2)
+    print()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("accession", help="PXD accession, MassIVE MSV accession, or MassIVE task id")
+    parser.add_argument(
+        "--mode",
+        choices=("raw", "acquisition", "all"),
+        default="raw",
+        help="Which file classes to emit: vendor raw only, acquisition files (raw + mzML/mzXML), or all files",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "tsv", "json"),
+        default="text",
+        help="Output format",
+    )
+    parser.add_argument(
+        "--ftp-url",
+        help="Override the FTP root when the repository metadata is incomplete",
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Resolve and print dataset-level metadata without walking the FTP tree",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    resolution = resolve_accession(args.accession)
+    if args.summary_only:
+        emit_json(resolution, resolution.ftp_url, [])
+        return
+    candidates = [args.ftp_url] if args.ftp_url else ftp_candidates(resolution)
+    if not candidates:
+        raise SystemExit("Could not determine a MassIVE FTP root for this accession.")
+
+    last_error: Exception | None = None
+    files: list[str] = []
+    chosen_ftp: str | None = None
+    for ftp_url in candidates:
+        try:
+            host, path = parse_ftp_url(ftp_url)
+            files = ftp_walk_files(host, path, args.mode)
+            chosen_ftp = ftp_url
+            break
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            continue
+
+    if chosen_ftp is None:
+        if last_error:
+            raise SystemExit(f"Failed to list MassIVE files: {last_error}")
+        raise SystemExit("Failed to list MassIVE files.")
+
+    if args.format == "json":
+        emit_json(resolution, chosen_ftp, files)
+    elif args.format == "tsv":
+        emit_tsv(resolution, files)
+    else:
+        emit_text(files)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -33,6 +33,30 @@ Tool: get_project_files(project_accession="PXD######")
 Extract: raw file names (for comment[data file]), file count, file types
 ```
 
+If MCP access is unavailable or incomplete, prefer the PRIDE Archive REST fallback:
+```text
+GET https://www.ebi.ac.uk/pride/ws/archive/v3/projects/PXD######/files/all
+```
+Use this endpoint to retrieve the complete file list for the project in one call.
+It is the preferred REST path for counting files, checking raw-file coverage, and
+building `comment[data file]` values during annotation.
+If this endpoint returns `0` files for a valid PXD hosted through
+`PanoramaPublic`, `MassIVE`, `iProX`, or `jPOST`, treat that as
+`archive endpoint empty for external repository` rather than `no data`.
+For MassIVE-backed datasets, use the helper script in this repo to recover raw
+file names from ProteomeCentral + MassIVE JSON + MassIVE FTP:
+```text
+python scripts/massive_raw_files.py PXD016117 --mode raw
+python scripts/massive_raw_files.py PXD016117 --mode acquisition --format tsv
+```
+This is the preferred fallback when you need `comment[data file]` values for a
+MassIVE-hosted PXD and PRIDE does not expose the archive file list.
+Also inspect companion files under MassIVE `other/` or supplementary dataset
+attachments. In practice these often contain the curator key you need for TMT
+channel-to-sample mapping, pooled-reference channels, blanks, longitudinal
+timepoints, or cohort aliases that are not recoverable from PRIDE metadata
+alone.
+
 ### 1.3 Find and read the publication
 ```text
 a. Extract PMID or DOI from PRIDE response (publications field)
@@ -51,11 +75,81 @@ Read the paper systematically and extract:
 - How many samples? How many conditions/groups?
 - Tissues/cell types per group
 - Patient demographics (age, sex, ancestry) if available
+- Developmental stage when the cohort is clearly adult, pediatric, fetal, juvenile, etc.
 - Experimental conditions (treatment, disease state, time points)
 - Labeling strategy (which TMT/iTRAQ channels for which samples)
 - Fractionation details (number of fractions, method)
 - Instrument and acquisition method details
 - Modifications searched
+
+Demographic evidence rules:
+- `characteristics[developmental stage]` can be added from cohort-level evidence when the whole analyzed cohort is clearly in one stage, for example all subjects are adults or the study is explicitly pediatric.
+- `characteristics[age]`, `characteristics[sex]`, and `characteristics[ethnicity]` should be added only when they can be mapped to individual source samples or a per-sample supplementary table.
+- If the paper reports only group summaries such as median age, percent male, or ethnicity distribution, keep those fields out of per-sample SDRF rows and mention the limitation in the notes.
+
+### 1.4b Map PRIDE source samples to ENA/BioSamples when possible
+For datasets with paired ENA/SRA/BioSamples records, especially metaproteomics studies:
+
+- Treat BioSample accessions as **source-sample identifiers**, not raw-file identifiers
+- A repeated BioSample accession across many SDRF rows is correct when those rows share the same `source name`
+- Do **not** assume one BioSample per raw file, fraction, or technical replicate
+
+Use this mapping order:
+
+1. Prefer **exact study-linked lookups** in ENA or BioSamples:
+   - ENA sample search by study/BioProject accession
+   - BioSamples exact filters on project/study accessions
+2. Compare the returned sample metadata against the paper and PRIDE:
+   - collection date
+   - geographic location / coordinates
+   - isolation source / environmental medium
+   - sample title / alias
+   - whether the study describes one shared source sample or multiple distinct source samples
+3. Add `characteristics[biosample accession number]` only when:
+   - the PRIDE `source name` clearly maps to a deposited ENA/BioSamples sample, or
+   - there is one well-supported shared source sample that all assay rows derive from
+
+Avoid this failure mode:
+
+- BioSamples UI free-text search can return unrelated accessions through fuzzy matching
+- Treat UI text-search hits as **leads only**, not evidence
+- Confirm project membership with exact ENA/BioSamples study-linked queries before annotating
+
+Metaproteomics rule of thumb:
+
+- if all rows in one SDRF share one `source name`, one `biological replicate`, and differ only by fraction / technical replicate / workflow, repeating one BioSample accession across those rows is usually the correct representation
+- if the paper describes multiple distributed aliquots from one shared environmental source sample, a single repeated BioSample accession may still be appropriate if the external record clearly represents that shared source sample
+
+### 1.5 Guard plasma campaigns against false positives
+If the user is targeting blood-plasma projects:
+- default to `Homo sapiens` unless the user explicitly requests animal studies
+- confirm species with PRIDE `organisms` first
+- if PRIDE species is incomplete, use the linked paper to confirm that the plasma cohort is human-only before promotion
+- keep mouse, rat, or mixed-species plasma projects as audit-only candidates until the user asks for them
+- expand the disease through OLS before PRIDE discovery:
+  - lexical OLS first in `MONDO`, `DOID`, `EFO`, and `NCIT`
+  - add useful synonyms and preferred labels
+  - use OLS embeddings for broad disease names when subtype phrasing is likely in PRIDE, for example `kidney tumor` -> renal cancer variants
+  - keep in-scope child terms when biomarker studies use the subtype rather than the parent label, for example `myositis` -> `dermatomyositis`, `sarcoma` -> `Ewing sarcoma`, `myeloma` -> `multiple myeloma`, or `alcohol-related liver disease` -> `alcoholic hepatitis`
+  - for influenza-like campaigns, acceptable widening can include `influenza A`, `IAV`, `H1N1`, `flu`, and, if explicitly allowed by the user, broader `viral pneumonia` plus `serum`
+  - tag each promoted candidate as an `exact`, `child_term`, `related`, or `surrogate` disease match so later ranking is honest about coverage strength
+- classify the project workflow from PRIDE before prioritizing it:
+  - read `experimentTypes` for acquisition style like `Data-independent acquisition`, `Data-dependent acquisition`, or `Gel-based experiment`
+  - read `quantificationMethods` for explicit quant style like `TMT`, `iTRAQ`, `label-free quantification`, `Dimethyl Labeling`, or `NSAF`
+  - if those fields are incomplete, inspect `sampleProcessingProtocol`, `dataProcessingProtocol`, keywords, and the manuscript methods section for explicit `TMT`, `iTRAQ`, `LFQ`, `DIA`, `SWATH`, `MaxQuant`, or `Spectronaut` wording
+  - keep separate `acquisition_mode` and `quant_mode` annotations rather than collapsing everything into one label
+- treat `blood plasma`, `plasma proteome`, `plasma samples`, and `plasma extracellular vesicles` as valid plasma-sample signals
+- do NOT treat `plasma cells` or `plasma membrane` as blood-plasma sample signals
+- for the current plasma-dataset campaigns, only promote datasets hosted by `PRIDE`, `MassIVE`, `jPOST`, or `iProX`; keep `PanoramaPublic` hits as audit-only candidates for now
+- for automatic discovery or ranking, only shortlist accessions when plasma context is present (`positive` or `ambiguous`) and the disease is explicit in the title, description, or linked paper
+- keep `plasma_context=missing` disease hits as audit-only candidates until manuscript or PRIDE evidence confirms a real blood-plasma sample
+- if a candidate dataset lacks usable raw or acquisition files, do not promote it into the active annotation set even if the disease and matrix match
+- when a manuscript is available, classify the accession before annotation:
+  - `confirmed_plasma` if plasma is explicit in title, abstract, methods, results, or supplementary text
+  - `mixed_includes_plasma` if plasma is explicit but the study also includes CSF, serum, tissue, urine, or cell-line material
+  - `likely_non_plasma` if the manuscript points to a different primary matrix such as CSF, platelet releasate, urine, BALF, or cell-line material
+  - `unclear` if the paper cannot confirm plasma; do not auto-promote these datasets into a plasma campaign
+- if the accession is already present in the local plasma collection, refine the existing SDRF instead of creating a duplicate target
 
 If **no PXD** but an experiment description, skip to Step 2.
 
@@ -86,7 +180,7 @@ Organize columns in this order:
 
 **Characteristics columns (sample metadata):**
 - All `characteristics[...]` columns from TERMS.tsv for the selected templates
-- Order: organism, organism part, disease, cell type, material type, then template-specific (age, sex, cell line, etc.), then biological replicate
+- Order: organism, organism part, disease, cell type, material type, then template-specific (developmental stage, age, sex, cell line, etc.), then biological replicate
 
 **Anchor + technology:**
 - `assay name`
@@ -105,15 +199,58 @@ Organize columns in this order:
 
 ## Step 4: Fill Sample Metadata
 
+Before filling demographic fields, decide whether the paper supports:
+- cohort-level demographic context only
+- or true sample-level demographic assignment
+
+Use this rule:
+- `developmental stage` may come from cohort-level manuscript evidence if the full analyzed cohort is unambiguously adult, pediatric, fetal, juvenile, and so on
+- `age`, `sex`, and `ethnicity` require source-sample or individual-level mapping
+- if only cohort summaries exist, leave per-sample demographic fields as missing / omitted rather than guessing
+
 For EACH unique value that goes into a characteristics column:
 
-### 4.1 Search OLS for the correct ontology term
+### 4.1 Normalize a short mention first
+- If the value already comes from PRIDE metadata or an existing SDRF cell, clean that value and use it directly.
+- If the value comes from a manuscript, first extract the shortest standalone entity phrase and keep the sentence only as evidence.
+- Search the expanded form before the abbreviation when both are available.
+- Do NOT send full manuscript sentences to OLS or ZOOMA unless you are debugging a failed lookup.
+
+### 4.2 Search OLS lexically first
 ```text
 Use: searchClasses(query="breast carcinoma", ontologyId="mondo")
 Or: search(query="Homo sapiens")
 ```
+For clean SDRF-like values, lexical exact or synonym matches are the default path and usually outperform embeddings.
 
-### 4.2 Verify the term is from the CORRECT ontology
+### 4.3 Use embeddings and ZOOMA only when needed
+Trigger OLS embedding search when:
+- lexical search returns no result
+- the mention is abbreviation-like (`HCC`, `PDAC`, `GBM`, `TNBC`)
+- the top lexical hits are conflicting or clearly over-specific
+- the mention came from noisy manuscript text rather than a curated label
+
+Use the OLS MCP tools in this order:
+```text
+1. listEmbeddingModels()
+2. searchClassesWithEmbeddingModel(query="<clean phrase>", ontologyId="<ontology>", model="<embed model>")
+3. If ontology-specific search is unavailable, use searchWithEmbeddingModel() and filter manually
+```
+
+Use ZOOMA as a slower fallback for manuscript-derived free text or when lexical and embedding results still disagree:
+```text
+GET https://www.ebi.ac.uk/spot/zooma/v2/api/services/annotate?propertyValue=<clean phrase>&propertyType=<field>
+```
+- Accept only `HIGH` or `GOOD` confidence mappings from ZOOMA
+- Always verify returned `semanticTags` in OLS and confirm the ontology is allowed by `TERMS.tsv`
+- Use ZOOMA mainly for disease, phenotype, treatment, or other curator-style phrases backed by prior curation
+
+Field defaults:
+- `organism`, `cell line` → lexical first, fallback methods rarely needed
+- `organism part`, `cell type`, `treatment` → lexical first, embeddings/ZOOMA only if lexical is weak
+- `disease`, `phenotype` → lexical first, embeddings and ZOOMA are useful fallbacks
+
+### 4.4 Verify the term is from the CORRECT ontology
 Read TERMS.tsv `values` field for the column to determine which ontology(ies) to search:
 - organism → NCBITaxon
 - organism part → UBERON (primary), BTO (fallback)
@@ -122,14 +259,47 @@ Read TERMS.tsv `values` field for the column to determine which ontology(ies) to
 - cell line → CLO, BTO, EFO (+ Cellosaurus for accession)
 - instrument → MS, PRIDE
 - modifications → UNIMOD
+- biosample accession number → exact BioSample accession from ENA/BioSamples only; do not infer from fuzzy search alone
 
-### 4.3 Check specificity
+For organisms, prefer the current NCBITaxon label over legacy synonyms when validation fails on an older name.
+Crosslinking cleanup examples that should be normalized before final validation:
+- `chaetomium thermophilum` → `thermochaetoides thermophila`
+- `chlorobium tepidum` → `chlorobaculum tepidum`
+- `canis familiaris` → `canis lupus familiaris`
+- `deinococcus radiodurans r1` → `deinococcus radiodurans`
+
+For crosslinking-specific assay cleanup, use explicit file-name evidence when the SDRF still says `NT=unknown crosslinker;AC=XLMOD:00000`. Safe examples seen in sandbox cleanup:
+- file names containing `DSSO` → `NT=DSSO;AC=XLMOD:02010;CL=yes;TA=K,S,T,Y,nterm;MH=54.01;ML=85.98`
+- file names containing `BS3` → `NT=BS3;AC=XLMOD:02000`
+- file names containing `TurboID` → `NT=TurboID;AC=XLMOD:02251`
+- file names containing `iQPIR`, `BDP`, or `d8BDP` → `NT=PIR;AC=XLMOD:02014`
+
+After recovering a known cross-linker, backfill `characteristics[crosslink distance]` when the template guidance is explicit:
+- `BS3` / `DSS` → `30 Å`
+- `DSSO` → `26.4 Å`
+- `EDC` → `11.4 Å`
+- `formaldehyde` → `2 Å`
+- `DSBU` / `DSBSO` → `26.4 Å`
+- `SDA` / `sulfo-SDA` → `18 Å`
+
+For `comment[crosslink enrichment method]`, use explicit separation tokens from `comment[data file]` when the field is still missing:
+- `SCX` → `strong cation exchange chromatography`
+- `SEC` → `size exclusion chromatography`
+- `FAIMS` → `FAIMS`
+- dataset title containing `streptavidin pull-down` → `streptavidin pull-down`
+- dataset title containing `IMAC-enrichable` → `immobilized metal affinity chromatography`
+- dataset title containing `CuAAC-enrichable` → `CuAAC enrichment`
+
+When one of those enrichment-method values is recovered and `characteristics[enrichment process]` is still missing, backfill `enrichment of cross-linked peptides`.
+
+### 4.5 Check specificity
 - "cancer" → too generic, use "breast carcinoma" or specific subtype
 - "tissue" → too generic, use "liver" or "temporal cortex"
 - "cell" → too generic, use "T cell" or "epithelial cell"
 - Use getChildren() to see if there's a more specific child term
+- If embeddings or ZOOMA suggest a child term that is more specific than the paper text supports, prefer the broader lexical term and note the ambiguity
 
-### 4.4 Use reserved words correctly
+### 4.6 Use reserved words correctly
 - `not available` — information exists but was not provided
 - `not applicable` — property doesn't apply to this sample
 - `normal` — healthy control (for disease column, use with PATO:0000461)
@@ -143,6 +313,12 @@ Read TERMS.tsv `values` field for the column to determine which ontology(ies) to
 searchClasses(query="Q Exactive", ontologyId="ms")
 Format in SDRF: AC=MS:1001911;NT=Q Exactive HF
 ```
+
+If validation complains about an instrument term that is also documented in the
+official PSI-MS / ProteomeXchange schema, verify the accession first instead of
+rewriting the instrument blindly. Example: `LTQ Orbitrap Elite` with
+`MS:1001910` may warn in some validator/cache combinations even though the term
+is publicly documented.
 
 ### 5.2 Modifications — CRITICAL
 Use EXACT UNIMOD accessions. Common setup:
@@ -263,13 +439,13 @@ Present the validated SDRF as a TSV code block and explain:
 
 If the annotation was for a **ProteomeXchange dataset** (PXD accession):
 
-1. Check if this PXD already exists in `bigbio/sdrf-annotated-datasets` under `datasets/{PXD}/`
+1. Check if this PXD already exists in `spec/annotated-projects/{PXD}/`
 2. Tell the user their annotation can be contributed to the community:
 
 ```text
 Your SDRF annotation for {PXD} is ready!
 
-The sdrf-annotated-datasets community repository collects annotated SDRF files
+The proteomics-sample-metadata community repository collects annotated SDRF files
 for ProteomeXchange datasets. Contributing your annotation means:
   - Other researchers can reuse your metadata
   - Analysis pipelines (quantms) can automatically reprocess the dataset
@@ -278,7 +454,7 @@ for ProteomeXchange datasets. Contributing your annotation means:
 Run /sdrf:contribute {PXD} to create a PR, or see the commands to do it manually.
 ```
 
-3. If the PXD already exists in `datasets/`, mention this is an update to an existing annotation
+3. If the PXD already exists in annotated-projects/, mention this is an update to an existing annotation
 
 This step is a recommendation only — do not force the user to contribute.
 

--- a/skills/sdrf-autoresearch/SKILL.md
+++ b/skills/sdrf-autoresearch/SKILL.md
@@ -1,0 +1,387 @@
+---
+name: sdrf:autoresearch
+description: Use when the user wants SDRF annotation to run as an autonomous retained-improvement loop over one dataset, a manifest, or a dataset class such as all PRIDE cell line or crosslinking datasets.
+user-invocable: true
+argument-hint: 'target="<dataset scope>" [profile="<preset>"] [objective="<metric>"] [focus_fields="<field1,field2>"] [evidence="<pride,files,europepmc>"] [stop="<rule>"] [write="<sandbox|branch|report-only>"]'
+---
+
+# SDRF Autoresearch Protocol
+
+This workflow is a domain-specific autonomous loop for SDRF annotation.
+It is intended to function with minimal user supervision once the target and
+optimization goal are clear.
+
+Use it when the user asks for:
+- annotation of all datasets in a category
+- repeated refine → validate → fix loops
+- maximum metadata completion without blind guessing
+- autonomous SDRF improvement until no more retained gains are possible
+
+This is a protocol skill, not a dedicated runner script. Execute the loop by
+following the steps below and by calling the existing `sdrf:*` skills in order.
+
+## Console Triggers
+
+Claude-style examples:
+```text
+/sdrf:autoresearch target="all PRIDE cell line datasets"
+/sdrf:autoresearch target="all sandbox crosslinking datasets" profile="crosslinking"
+/sdrf:autoresearch target="manifest:data/cell_line_manifest.tsv" objective="maximize_valid_field_coverage"
+```
+
+Codex-style examples:
+```text
+$sdrf-autoresearch target="all PRIDE cell line datasets"
+$sdrf-autoresearch target="accessions:PXD001234,PXD005678" profile="clinical"
+$sdrf-autoresearch target="all sandbox crosslinking datasets" objective="crosslinking_assay_completion" write="sandbox"
+```
+
+## Step 1: Parse the Request into a Loop Config
+
+Normalize the user request into these fields:
+
+- `target`
+  - What dataset set to operate on
+  - Examples:
+    - `all PRIDE cell line datasets`
+    - `all sandbox crosslinking datasets`
+    - `manifest:data/cell_line_manifest.tsv`
+    - `accessions:PXD001234,PXD005678`
+
+- `profile`
+  - Domain preset that biases which templates, columns, and evidence sources matter most
+  - Supported defaults:
+    - `general-proteomics`
+    - `cell-line`
+    - `crosslinking`
+    - `clinical`
+    - `immunopeptidomics`
+
+- `objective`
+  - The optimization target for retained improvements
+  - Supported defaults:
+    - `maximize_valid_field_coverage`
+    - `minimize_unknowns`
+    - `crosslinking_assay_completion`
+    - `cell_line_sample_completion`
+    - `clinical_sample_completion`
+
+- `focus_fields`
+  - Optional list of fields to prioritize
+  - Examples:
+    - `cell line,disease,organism part,treatment`
+    - `cross-linker,crosslink enrichment method,collision energy`
+
+- `evidence`
+  - Which sources are allowed
+  - Defaults to `pride,files,europepmc`
+  - Common values:
+    - `pride,files`
+    - `pride,files,europepmc`
+    - `manuscript-first`
+
+- `stop`
+  - When the loop should stop
+  - Supported defaults:
+    - `3_no_improve_rounds`
+    - `coverage>=0.95`
+    - `only_low_confidence_candidates_left`
+
+- `write`
+  - Where edits should land
+  - Supported values:
+    - `sandbox`
+    - `branch`
+    - `report-only`
+
+If the user does not specify these explicitly, infer them conservatively and
+state the inferred config before the loop begins.
+
+## Step 2: Build the Dataset Target Set
+
+Interpret `target` into a concrete dataset set:
+
+- `accessions:...`
+  - Use those accessions directly
+
+- `manifest:...`
+  - Read the manifest TSV/CSV and use those datasets
+
+- `all PRIDE <category> datasets`
+  - Use PRIDE MCP + local manifests to discover datasets matching the category
+  - Examples:
+    - `cell line`
+    - `crosslinking`
+    - `human clinical`
+    - `immunopeptidomics`
+
+- `all sandbox <category> datasets`
+  - Use local sandbox inventory first
+
+Always resolve the target into a manifest-like working list before annotation begins.
+
+### Plasma Campaign Heuristic
+
+For `blood plasma` or `plasma biomarker` campaigns:
+
+1. Audit the local project collection first
+   - enumerate existing SDRFs under the relevant project tree
+   - separate true plasma SDRFs from blood-cell / tissue / platelet / serum-only SDRFs
+   - extract the current disease coverage before searching PRIDE
+
+2. Treat discovery as two layers
+   - `new_dataset`: accession not yet present in the local plasma collection
+   - `upgrade_existing_sdrf`: accession already present locally, but disease wording, ontology, or field coverage should be improved
+
+3. Default to human plasma unless the user explicitly says otherwise
+   - treat `Homo sapiens` as the default species scope for biomarker-style plasma campaigns
+   - use PRIDE `organisms` first to confirm species
+   - if PRIDE species is missing or generic, confirm human-only status from the manuscript title, abstract, methods, or supplementary text
+   - keep non-human or mixed-species plasma projects as audit rows, not as automatically promoted annotation targets
+
+4. When querying PRIDE, do not trust `plasma` hits blindly
+   - expand disease names before PRIDE search:
+      - start with lexical OLS disease lookup in `MONDO`, `DOID`, `EFO`, and `NCIT`
+      - add useful exact labels and synonyms
+      - for broad disease requests like `kidney tumor`, use OLS embedding search to surface likely subtype names such as renal-cancer variants
+      - keep useful child-term labels when the study is still clearly in scope, for example `myositis` -> `dermatomyositis`, `sarcoma` -> `Ewing sarcoma`, `myeloma` -> `multiple myeloma`, or `alcohol-related liver disease` -> `alcoholic hepatitis`
+      - for influenza-like campaigns, acceptable query widening can include `influenza A`, `IAV`, `H1N1`, `flu`, and, if the user explicitly allows it, broader `viral pneumonia` plus `serum`
+      - then query PRIDE and Europe PMC with the expanded disease family, not only the original user wording
+     - record whether a promoted hit is an `exact`, `child_term`, `related`, or `surrogate` disease match so downstream ranking does not overstate coverage
+   - annotate the candidate workflow class during discovery:
+     - use PRIDE `experimentTypes` for acquisition style such as `Data-independent acquisition`, `Data-dependent acquisition`, `Gel-based experiment`, or `Bottom-up proteomics`
+     - use PRIDE `quantificationMethods` first for labeling style such as `TMT`, `iTRAQ`, `label-free quantification`, `Dimethyl Labeling`, or `NSAF`
+     - if `quantificationMethods` is empty, inspect `sampleProcessingProtocol`, `dataProcessingProtocol`, and keywords for explicit terms like `TMT16plex`, `iTRAQ`, `label-free quantification`, `LFQ`, `MaxQuant`, `DIA`, `SWATH`, or `Spectronaut`
+     - store separate `acquisition_mode` and `quant_mode` columns so campaigns can prioritize `DIA-LFQ`, `DDA-TMT`, `DDA-LFQ`, and related workflows explicitly
+   - distinguish `blood plasma` / `plasma proteome` / `plasma extracellular vesicles` from false positives such as `plasma cells` or `plasma membrane`
+   - for the current plasma-dataset campaigns, keep only accessions hosted by `PRIDE`, `MassIVE`, `jPOST`, or `iProX`; treat `PanoramaPublic` discoveries as audit-only until the campaign policy changes
+   - prefer candidates where both the disease and the blood-plasma context are explicit in the title or description
+   - for automatic shortlist generation, only promote accessions when plasma context is `positive` or `ambiguous` and the disease context is `explicit`
+   - keep disease-only hits with missing plasma context as low-confidence discovery rows, not as prioritized plasma projects
+   - do not promote datasets that lack usable raw or acquisition files; keep them as audit-only rows even if the disease and matrix look promising
+   - after shortlist generation, run a manuscript-backed plasma review and classify each accession as:
+     - `confirmed_plasma`: explicit plasma evidence in title, abstract, methods, results, or supplementary text
+     - `mixed_includes_plasma`: plasma is explicit, but other sample matrices are also part of the study
+     - `likely_non_plasma`: manuscript shows a different primary matrix such as CSF, urine, platelet releasate, BALF, or cell-line material
+     - `unclear`: insufficient manuscript evidence; do not prioritize automatically
+   - prefer `confirmed_plasma` first, then `mixed_includes_plasma` if mixed-matrix studies are acceptable for the campaign
+
+5. Search Europe PMC independently when publication links may be missing from PRIDE
+   - run disease-focused Europe PMC queries even when PRIDE does not already point to a publication
+   - include `PXD`, `PRIDE`, or `ProteomeXchange` in the literature query to favor papers that reference a proteomics dataset
+   - when a paper is open access, inspect the full text and extract explicit `PXD...` / `MSV...` mentions
+   - use the literature-side accession hits to cross-link back into PRIDE and recover datasets that are weakly linked or unlinked in the archive record
+
+6. Prioritize candidates in this order
+   - missing disease coverage with explicit blood-plasma context
+   - related-only local coverage where a disease-specific plasma accession exists
+   - already covered diseases only when the existing local SDRF is clearly incomplete
+
+## Step 3: Choose the Scoring Objective
+
+Do not optimize for raw field count alone.
+Optimize for valid, evidence-supported, template-compliant completion.
+
+Default scoring dimensions:
+
+1. Required-field completion
+2. Recommended-field completion
+3. Objective-specific completion
+4. Validation success
+5. Ontology quality
+6. Evidence support
+7. Placeholder penalty
+
+Recommended derived objectives:
+
+### `maximize_valid_field_coverage`
+
+Use when the user wants the most complete valid SDRF possible.
+
+Reward:
+- required columns present and filled
+- recommended columns present and filled
+- validated ontology terms
+- technical metadata recovered from files or manuscript evidence
+
+Penalize:
+- `not available`, `not applicable`, `unknown`
+- invalid ontology terms
+- unsupported guesses
+
+### `minimize_unknowns`
+
+Use when the main problem is placeholders and unresolved values.
+
+Reward:
+- replacing `unknown` and `unknown crosslinker`
+- resolving generic metadata into validated terms
+
+Penalize:
+- replacements that are not evidence-backed
+
+### `crosslinking_assay_completion`
+
+Use for XL-MS datasets.
+Focus strongly on:
+- `comment[cross-linker]`
+- `comment[crosslink enrichment method]`
+- `characteristics[enrichment process]`
+- `characteristics[crosslink distance]`
+- `comment[crosslinker concentration]`
+- `characteristics[crosslinking reaction time]`
+- `characteristics[crosslinking temperature]`
+- `comment[quenching reagent]`
+- `comment[collision energy]`
+
+### `cell_line_sample_completion`
+
+Use for cell line datasets.
+Focus strongly on:
+- `characteristics[cell line]`
+- `characteristics[cell type]`
+- `characteristics[disease]`
+- `characteristics[organism part]`
+- `characteristics[treatment]`
+- `characteristics[sex]`
+- `characteristics[age]`
+
+For human or clinical campaigns, also treat demographic evidence conservatively:
+- promote `characteristics[developmental stage]` when the cohort is clearly adult, pediatric, fetal, juvenile, and so on, even if the paper reports only cohort-level age summaries
+- do not auto-fill per-sample `characteristics[age]`, `characteristics[sex]`, or `characteristics[ethnicity]` unless the manuscript or supplementary tables map them to individual source samples
+- if only cohort summaries exist, record the evidence in notes rather than forcing those values into every SDRF row
+
+## Step 4: Run the Annotation Loop
+
+For each dataset:
+
+1. Discover evidence
+   - PRIDE metadata
+   - PRIDE files
+   - manuscript from Europe PMC when available
+   - supplementary and tables for sample metadata
+   - methods for technical metadata
+
+   For PRIDE file discovery, prefer the complete Archive REST endpoint when you
+   need exact file coverage or file counts:
+   ```text
+   GET https://www.ebi.ac.uk/pride/ws/archive/v3/projects/PXD######/files/all
+   ```
+   Use this to avoid partial paged counts when auditing raw files, checking
+   whether a candidate accession is tractable, or comparing SDRF `comment[data file]`
+   values against the archive.
+   If this endpoint returns `0` files for a valid PXD hosted through
+   `PanoramaPublic`, `MassIVE`, `iProX`, or `jPOST`, treat that as
+   `archive endpoint empty for external repository` rather than `no dataset`.
+   Keep the accession in play and note the repository-backed limitation in the
+   ranking output.
+
+2. Run `/sdrf:annotate`
+   - draft or extend the SDRF using the selected templates
+
+3. Run `/sdrf:terms`
+   - normalize ontology-backed fields
+   - use lexical OLS first
+   - use embeddings for fuzzy manuscript-derived mentions
+   - use ZOOMA as slower fallback when useful
+
+4. Run `/sdrf:techrefine`
+   - refine technical MS metadata when raw files or techsdrf evidence are available
+
+5. Run `/sdrf:validate`
+   - validate template structure, reserved words, and ontology-backed fields
+   - keep validation concurrency bounded: default to serial, and never run more than `2` `parse_sdrf` jobs at once
+   - if `sdrf-techrefine`, raw-file conversion, or other heavy analysis is active, validate only `1` dataset at a time
+
+6. Run `/sdrf:fix`
+   - apply safe corrections to known SDRF error patterns
+
+7. Run `/sdrf:improve`
+   - rescore completeness, specificity, consistency, standards, and design
+
+8. Keep or discard
+   - keep only if the score improves and validation does not regress
+   - discard any refinement that adds unsupported metadata
+
+## Step 5: Repeat Until the Stop Rule Fires
+
+Repeat the full loop until one of these is true:
+
+- no retained improvement for 3 rounds
+- objective score crosses the configured threshold
+- only low-confidence or unsupported candidates remain
+- the remaining work is clearly manual-only
+
+Never keep looping just to replace placeholders with guesses.
+
+## Validation Resource Guard
+
+Autonomous annotation must not compromise the machine.
+
+Use these defaults:
+
+- `validation_mode=serial` unless there is a demonstrated need for limited parallel validation
+- `max_validation_jobs=2`
+- `max_validation_jobs=1` whenever raw-file analysis, file conversion, or large manuscript processing is already active
+- validate changed datasets first
+- use representative smoke checks before full collection sweeps
+
+If validation hangs or the system becomes resource-constrained, reduce the number of concurrent validators before continuing.
+
+## Step 6: Refinement Heuristics by Evidence Source
+
+Prioritize evidence as follows:
+
+### Sample metadata
+
+Best sources:
+- PRIDE sample description
+- manuscript Methods
+- manuscript Results
+- supplementary sample tables
+- figure and table captions
+
+### Technical metadata
+
+Best sources:
+- raw-file analysis
+- PRIDE protocols
+- manuscript Methods
+- search-parameter tables
+
+### File mapping and replicate logic
+
+Best sources:
+- PRIDE file list
+- SDRF row structure
+- file names
+
+## Step 7: Output Requirements
+
+At the end of the run, report:
+
+- resolved target set
+- inferred or explicit config
+- retained vs discarded rounds
+- final score or stopping condition
+- files changed
+- remaining unresolved high-value gaps
+
+If `write=report-only`, produce the same retained-improvement report without writing SDRFs.
+
+## Example Configs
+
+### Cell lines
+```text
+/sdrf:autoresearch target="all PRIDE cell line datasets" profile="cell-line" objective="maximize_valid_field_coverage" focus_fields="cell line,disease,organism part,treatment" evidence="pride,files,europepmc" stop="3_no_improve_rounds" write="sandbox"
+```
+
+### Crosslinking
+```text
+/sdrf:autoresearch target="all sandbox crosslinking datasets" profile="crosslinking" objective="crosslinking_assay_completion" focus_fields="cross-linker,crosslink enrichment method,collision energy,crosslinking reaction time" evidence="pride,files,europepmc" stop="only_low_confidence_candidates_left" write="sandbox"
+```
+
+### Report-only review
+```text
+/sdrf:autoresearch target="manifest:data/review_set.tsv" objective="minimize_unknowns" write="report-only"
+```

--- a/skills/sdrf-review/SKILL.md
+++ b/skills/sdrf-review/SKILL.md
@@ -34,6 +34,7 @@ If a publication is available:
 - Are all conditions from the paper represented?
 - Do the instruments match?
 - Are demographics (age, sex) consistent with the paper?
+- Is `characteristics[developmental stage]` supported by the cohort description even if age is reported only at group level?
 - Are tissue types correctly annotated?
 
 Flag any discrepancies:
@@ -52,6 +53,7 @@ When SDRF and paper/PRIDE disagree:
 - **Instrument mismatch**: PRIDE might say "Q Exactive" while paper says "Q Exactive HF". The paper is usually more specific — update SDRF to match the paper's instrument model.
 - **Tissue specificity**: If paper says "hippocampus" but SDRF says "brain", update SDRF to the more specific term from the paper.
 - **Demographic mismatch**: If paper has a demographics table, prioritize it. SDRF might have been filled from incomplete metadata.
+- **Cohort-only demographics**: If the paper reports only cohort summaries, `developmental stage` may still be supportable, but do not force per-sample `age`, `sex`, or `ethnicity` without an individual-level mapping table.
 - **File count mismatch**: Some files in PRIDE may be non-raw (search results, FASTA, etc.). Compare only raw files.
 
 ## Step 4: Cross-Reference with PRIDE
@@ -61,6 +63,16 @@ If a PXD accession is available:
   ```text
   mcp PRIDE → get_project_files(project_accession="PXD######")
   ```
+  REST fallback:
+  ```text
+  GET https://www.ebi.ac.uk/pride/ws/archive/v3/projects/PXD######/files/all
+  ```
+  If the project is hosted by MassIVE and PRIDE returns `0` files, use:
+  ```text
+  python scripts/massive_raw_files.py PXD###### --mode raw --format tsv
+  ```
+  to compare SDRF `comment[data file]` values against the MassIVE-backed raw
+  file list.
 - Does the organism match?
 - Does the instrument match?
 - Are all raw files accounted for?

--- a/skills/sdrf-validate/SKILL.md
+++ b/skills/sdrf-validate/SKILL.md
@@ -16,6 +16,22 @@ Verify that `parse_sdrf` is available (run `parse_sdrf --version` or `which pars
 - Suggest `/sdrf:setup` or `conda env create -f environment.yml && conda activate sdrf-skills` (or `pip install -r requirements.txt`)
 - Continue with structural and ontology checks; manual validation is still valuable
 
+## Step 0.5: Protect the Machine During Validation
+
+Validation can be expensive because `parse_sdrf` may trigger ontology lookups,
+template loading, and large file parsing.
+
+Use these resource guards:
+
+- Default to serial validation for autonomous loops unless there is a clear reason to parallelize
+- If validating multiple SDRFs in parallel, keep the concurrency small: at most `2` `parse_sdrf` jobs at a time
+- If `techsdrf`, raw-file conversion, or other heavy IO/CPU work is running, validate only `1` SDRF at a time
+- Validate changed datasets first, not the whole collection by default
+- Prefer batch manifests or representative smoke checks before full-sandbox sweeps
+- For large SDRFs, validate unique values once rather than re-checking repeated ontology terms row by row
+
+If the machine looks stressed or validation becomes unresponsive, reduce concurrency before continuing.
+
 ## Step 1: Parse the SDRF
 
 1. Read the SDRF content (from file path or pasted content)
@@ -98,16 +114,70 @@ For all other template-specific columns, read from TERMS.tsv rather than using a
 - [ ] `comment[sdrf version]` matches semver pattern (vX.Y.Z)
 - [ ] Check TERMS.tsv `allow_not_available`, `allow_not_applicable`, `allow_pooled` fields for each column to verify reserved words are valid
 
+### 3.4 Demographic Evidence Checks
+- [ ] If `characteristics[developmental stage]` is filled, verify the paper or metadata supports a single clear stage for the analyzed cohort or for that individual sample
+- [ ] Accept cohort-level support for `developmental stage` values such as `adult`, `pediatric`, `juvenile`, or `fetal` when the entire analyzed cohort is unambiguous
+- [ ] Do not require `characteristics[age]`, `characteristics[sex]`, or `characteristics[ethnicity]` to be filled just because the paper has cohort summaries
+- [ ] If `age`, `sex`, or `ethnicity` are filled per sample, verify that the manuscript or supplementary data maps them to individual source samples rather than only to group-level summaries
+- [ ] If only cohort-level summaries exist, prefer omission or `not available` over guessed per-sample demographic values
+
 ## Step 4: Ontology Validation
 
 For EACH unique value in ontology-controlled columns, verify via OLS.
 Use TERMS.tsv `values` field to determine which ontology(ies) to search for each column.
+
+Use this search order for ambiguous values:
+1. Clean the value first (strip Python/list artifacts, trim whitespace, expand abbreviations if known)
+2. Run lexical OLS search in the ontology family allowed by `TERMS.tsv`
+3. If lexical search fails or is clearly ambiguous, run OLS embedding search on the cleaned phrase
+4. If the value looks manuscript-derived free text or lexical and embedding results still disagree, try ZOOMA:
+   `https://www.ebi.ac.uk/spot/zooma/v2/api/services/annotate?propertyValue=<clean phrase>&propertyType=<field>`
+5. Verify any accepted candidate in OLS before marking it valid
+
+Default behavior by field:
+- `organism`, `cell line` → lexical first, fallback methods rarely needed
+- `organism part`, `cell type`, `treatment` → lexical first, fallback only if lexical is weak
+- `disease`, `phenotype` → lexical first, embeddings and ZOOMA are useful when values are messy or abbreviated
+
+Do NOT mark a term invalid just because embeddings or ZOOMA suggest a more specific descendant than the cell text supports; warn about specificity instead.
 
 ### Organism
 ```text
 searchClasses(query="<organism>", ontologyId="ncbitaxon")
 Verify: term exists, case is correct (Genus capitalized, species lowercase: "Homo sapiens")
 ```
+
+When an imported SDRF uses an older NCBITaxon synonym, prefer the current
+accepted label before declaring the row invalid. Common cleanup mappings seen in
+crosslinking datasets:
+- `chaetomium thermophilum` → `thermochaetoides thermophila`
+- `chlorobium tepidum` → `chlorobaculum tepidum`
+- `canis familiaris` → `canis lupus familiaris`
+- `deinococcus radiodurans r1` → `deinococcus radiodurans`
+
+If a crosslinking SDRF still uses `NT=unknown crosslinker;AC=XLMOD:00000`, inspect `comment[data file]` for explicit reagent tokens before accepting the placeholder. Examples validated in sandbox cleanup:
+- `DSSO` in file name → `NT=DSSO;AC=XLMOD:02010;CL=yes;TA=K,S,T,Y,nterm;MH=54.01;ML=85.98`
+- `BS3` in file name → `NT=BS3;AC=XLMOD:02000`
+- `TurboID` in file name → `NT=TurboID;AC=XLMOD:02251`
+- `iQPIR`, `BDP`, or `d8BDP` in file name → `NT=PIR;AC=XLMOD:02014`
+
+When a specific cross-linker is recovered, validate whether `characteristics[crosslink distance]` can be backfilled from the crosslinking template:
+- `BS3` / `DSS` → `30 Å`
+- `DSSO` → `26.4 Å`
+- `EDC` → `11.4 Å`
+- `formaldehyde` → `2 Å`
+- `DSBU` / `DSBSO` → `26.4 Å`
+- `SDA` / `sulfo-SDA` → `18 Å`
+
+For missing `comment[crosslink enrichment method]`, inspect `comment[data file]` for explicit enrichment tokens before leaving the field unresolved:
+- `SCX` → `strong cation exchange chromatography`
+- `SEC` → `size exclusion chromatography`
+- `FAIMS` → `FAIMS`
+- dataset title containing `streptavidin pull-down` → `streptavidin pull-down`
+- dataset title containing `IMAC-enrichable` → `immobilized metal affinity chromatography`
+- dataset title containing `CuAAC-enrichable` → `CuAAC enrichment`
+
+When one of those values is recovered and `characteristics[enrichment process]` is still missing, backfill `enrichment of cross-linked peptides`.
 
 ### Disease
 ```text
@@ -136,6 +206,12 @@ searchClasses(query="<instrument name>", ontologyId="ms")
 Verify: AC= matches the returned MS accession
 ```
 
+If the validator warns on an instrument term but the accession is present in the
+official PSI-MS / ProteomeXchange schema, treat it as a review item rather than
+an automatic correction. Example: `LTQ Orbitrap Elite` with `MS:1001910` has
+been observed to warn in some validation/cache combinations even though the term
+is publicly documented.
+
 ### Modifications — CRITICAL
 ```text
 Parse NT=, AC=, TA=, MT= from each comment[modification parameters]
@@ -160,6 +236,8 @@ Verify: AC= matches
 ### Performance Note
 For large SDRF files (100+ rows), validate unique values only — don't make redundant OLS calls for repeated values. Group by unique values first, then validate once per unique value.
 
+When validating multiple files, prefer small bounded batches. Do not launch large numbers of `parse_sdrf` jobs at once.
+
 ## Step 5: Consistency Checks
 
 - [ ] All rows have the same number of columns (no ragged rows)
@@ -174,6 +252,8 @@ For large SDRF files (100+ rows), validate unique values only — don't make red
 - [ ] `technology type` is the same across all rows
 - [ ] All `comment[modification parameters]` columns have the same value across all rows (modifications are experiment-wide, not per-sample)
 - [ ] `comment[instrument]` should be consistent (or documented if multiple instruments used)
+- [ ] `characteristics[sampling time]` uses the template pattern `number + unit` such as `0 day`, `8 day`, or `12 week` when time-course metadata is present
+- [ ] `characteristics[depletion]` uses the controlled values `depletion` or `no depletion` rather than local variants like `depleted` or `yes`
 
 ## Step 6: Report
 


### PR DESCRIPTION
## Summary
- add a MassIVE helper script for recovering raw and acquisition file names when PRIDE file listing is empty for externally hosted PXDs
- add the new `sdrf:autoresearch` protocol skill and expose it in the Codex/Claude skill docs
- teach the annotation, validation, review, and autoresearch workflows that `developmental stage` can come from clear cohort-level evidence, while age/sex/ethnicity still require sample-level mapping
- document the MassIVE fallback path in the SDRF skill workflows

## Validation
- `python3 -m py_compile scripts/massive_raw_files.py`
- manual read-back of the updated skill docs and clean cherry-pick onto `origin/main` before pushing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/sdrf:autoresearch` command for autonomous large-scale annotation loops with configurable targets, objectives, and stop conditions.
  * Added CLI tool for resolving MassIVE datasets and enumerating raw files via FTP with multiple output formats.

* **Documentation**
  * Enhanced SDRF annotation workflow with improved plasma campaign handling, demographic extraction, and ontology lookup procedures.
  * Updated validation workflow with concurrency guardrails and enhanced demographic/ontology verification.
  * Updated skill count and reference documentation across INSTALL and CLAUDE guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->