### PR TITLE
fix(completeness): add proteomics data acquisition method to required columns

### DIFF
--- a/tools/completeness.py
+++ b/tools/completeness.py
@@ -40,6 +40,7 @@ MS_PROTEOMICS_REQUIRED = BASE_REQUIRED + [
     "comment[precursor mass tolerance]",
     "comment[fragment mass tolerance]",
     "comment[label]",
+    "comment[proteomics data acquisition method]",
 ]
 
 # Columns recommended for human studies


### PR DESCRIPTION
## Summary

Add `comment[proteomics data acquisition method]` to `MS_PROTEOMICS_REQUIRED` in the completeness scorer.

## Motivation

### The problem: quantms crashes on valid DDA datasets

quantms reads this column to determine DDA vs DIA routing. If missing, the value resolves to `null`, which fails the substring check and causes `exit(1)` — even for legitimate DDA datasets:

```groovy
// quantms: subworkflows/local/create_input_channel/main.nf
if (row["Proteomics Data Acquisition Method"].toString().toLowerCase().contains("data-dependent acquisition")) {
    meta.acquisition_method = "dda"
} else {
    log.error("Currently only DDA is supported in quantms...")
    exit(1)
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated template requirements for proteomics data. A new required field for data acquisition method comments has been added. Completeness scoring will now flag this field as missing if not provided in SDRF inputs, and will adjust the overall completeness score accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->