### PR TITLE
docs: fix skill counts (→18) + harden helper scripts

### DIFF
--- a/.github/workflows/check-spec.yml
+++ b/.github/workflows/check-spec.yml
@@ -43,7 +43,7 @@ jobs:
             echo "| Current | \`${CURRENT:0:12}\` |" >> "$GITHUB_STEP_SUMMARY"
             echo "| Latest | \`${LATEST:0:12}\` |" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Run the [update-spec](/${{ github.repository }}/actions/workflows/update-spec.yml) workflow or update manually:" >> "$GITHUB_STEP_SUMMARY"
+            echo "Run the [update-spec](https://github.com/${{ github.repository }}/actions/workflows/update-spec.yml) workflow or update manually:" >> "$GITHUB_STEP_SUMMARY"
             echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
             echo "git submodule update --remote --recursive" >> "$GITHUB_STEP_SUMMARY"
             echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-14 structured workflow files that encode expert-level SDRF (Sample and Data
+18 structured workflow files that encode expert-level SDRF (Sample and Data
 Relationship Format) annotation methodology for proteomics.
 
 ## Skills Directory
@@ -15,6 +15,8 @@ description) followed by a step-by-step workflow in Markdown.
 | Skill Directory | What It Does |
 |----------------|-------------|
 | `sdrf-setup` | Install dependencies (parse_sdrf, techsdrf) — conda or pip guided setup |
+| `sdrf-metascreen` | Screen/shortlist PRIDE, MassIVE, or ProteomeXchange studies against user-defined criteria → evidence-backed TSV |
+| `sdrf-autoresearch` | Autonomous retained-improvement loop over one dataset, a manifest, or a dataset class |
 | `sdrf-knowledge` | SDRF format rules, column naming, ontology-to-column mapping |
 | `sdrf-templates` | Template layer system (Technology → Organism → Experiment → Clinical → Platform) |
 | `sdrf-annotate` | Full annotation workflow: PXD → PRIDE metadata + publication → SDRF draft |
@@ -29,6 +31,7 @@ description) followed by a step-by-step workflow in Markdown.
 | `sdrf-design` | Experimental design analysis: batch effects, confounders, replication assessment |
 | `sdrf-contribute` | Contribute annotated SDRF to community repo via PR (automated or guided) |
 | `sdrf-techrefine` | Verify/refine technical metadata (instrument, tolerances, mods, DDA/DIA) from raw files via techsdrf |
+| `sdrf-cellline` | Look up cell lines via Cellosaurus and translate them into SDRF cell-line columns (organism, disease, sampling site, sex, ancestry, age) |
 
 ## Specification Data
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ SDRF (Sample and Data Relationship Format) annotation in proteomics.
 
 ## What This Does
 
-16 structured workflows (SKILL.md files) that guide AI assistants through SDRF tasks
+18 structured workflows (SKILL.md files) that guide AI assistants through SDRF tasks
 using existing MCP tools (OLS, PRIDE, PubMed, bioRxiv, EuropePMC).
 Instead of guessing at ontology terms or validation rules, skills encode the
 community's annotation expertise as repeatable methodology.
@@ -22,11 +22,12 @@ Skills read these files at runtime. When the spec changes, run `git submodule up
 
 ## Available Skills (all under `sdrf:` namespace)
 
-All 16 skills are user-invocable. Type `/sdrf:` and autocomplete will show them all.
+All 18 skills are user-invocable. Type `/sdrf:` and autocomplete will show them all.
 
 | Command | Purpose |
 |---------|---------|
 | `/sdrf:setup` | Install dependencies (parse_sdrf, techsdrf) — conda or pip guided setup |
+| `/sdrf:metascreen` | Screen/shortlist PRIDE, MassIVE, or ProteomeXchange studies against user-defined criteria → evidence-backed TSV for downstream annotation |
 | `/sdrf:autoresearch` | Autonomous retained-improvement loop over one dataset, a manifest, or a dataset class |
 | `/sdrf:knowledge` | SDRF format rules, column definitions (from TERMS.tsv), ontology routing, modification format, reserved words |
 | `/sdrf:templates` | Template system (from templates.yaml), selection rules, mutual exclusivity, inheritance |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,10 +5,12 @@ annotation in proteomics.
 
 ## Available Workflows
 
-The `skills/` directory contains 15 workflow files (SKILL.md) that encode community
+The `skills/` directory contains 18 workflow files (SKILL.md) that encode community
 annotation expertise. When working with SDRF files, consult the relevant skill:
 
 - **Setup**: `skills/sdrf-setup/SKILL.md` — install parse_sdrf, techsdrf (conda or pip)
+- **Screen**: `skills/sdrf-metascreen/SKILL.md` — shortlist PRIDE/MassIVE/ProteomeXchange studies against user criteria → evidence-backed TSV
+- **Autoresearch**: `skills/sdrf-autoresearch/SKILL.md` — autonomous retained-improvement loop over a dataset, manifest, or dataset class
 - **Format rules**: `skills/sdrf-knowledge/SKILL.md` — column naming, ontology mappings, modification format
 - **Templates**: `skills/sdrf-templates/SKILL.md` — 5-layer template system, selection rules
 - **Annotation**: `skills/sdrf-annotate/SKILL.md` — full PXD → SDRF workflow
@@ -23,6 +25,7 @@ annotation expertise. When working with SDRF files, consult the relevant skill:
 - **Design**: `skills/sdrf-design/SKILL.md` — experimental design analysis
 - **Contribute**: `skills/sdrf-contribute/SKILL.md` — PR to community repository
 - **Tech Refine**: `skills/sdrf-techrefine/SKILL.md` — verify/refine technical metadata from raw files via techsdrf
+- **Cell line**: `skills/sdrf-cellline/SKILL.md` — translate Cellosaurus records into SDRF cell-line columns (organism, disease, sex, sampling site, ancestry, age)
 
 ## Specification Data
 
@@ -41,3 +44,5 @@ Skills reference these files at runtime. Never hardcode specification data.
 4. Select templates before starting annotation — read `spec/sdrf-proteomics/sdrf-templates/templates.yaml`
 5. All terms need both label AND accession (e.g., "breast carcinoma" EFO:0000305)
 6. Modifications: NT=;AC=UNIMOD:;TA=;MT= format (watch for UNIMOD:1↔21 swap)
+7. Reserved words: "not available", "not applicable" — never "N/A", "NA", "unknown"
+8. Always validate with `parse_sdrf validate-sdrf --sdrf_file X --template Y` before presenting an SDRF; update the spec first with `git submodule update --remote --recursive`

--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ and is read at runtime — so the skills stay current when the spec evolves.
 
 ## Available skills
 
-All 16 skills are under the `sdrf:` namespace. In Claude Code, type `/sdrf:` and autocomplete will show them all.
+All 18 skills are under the `sdrf:` namespace. In Claude Code, type `/sdrf:` and autocomplete will show them all.
 
 | Skill | What it does |
 |-------|-------------|
 | `/sdrf:setup` | Install dependencies (parse_sdrf, techsdrf) — conda or pip guided setup |
 | `/sdrf:knowledge` | Ask about SDRF format, column rules, ontology mappings, reserved words |
 | `/sdrf:templates` | Ask about templates, select templates, understand layers and selection rules |
+| `/sdrf:metascreen` | Screen/shortlist PRIDE, MassIVE, or ProteomeXchange studies against user criteria → evidence-backed TSV |
+| `/sdrf:autoresearch` | Autonomous retained-improvement loop over a dataset, manifest, or dataset class |
 | `/sdrf:annotate` | Full annotation workflow: PXD → PRIDE + paper → draft SDRF → validate |
 | `/sdrf:validate` | Systematic validation against templates + ontology checking via OLS |
 | `/sdrf:improve` | Quality analysis: specificity, completeness, consistency, score |

--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,6 @@ dependencies:
   - sdrf-pipelines      # parse_sdrf CLI for validation and pipeline conversion
   - techsdrf            # raw file analysis for /sdrf:techrefine
   - thermorawfileparser # for Thermo .raw files (optional; techsdrf skips .raw without it)
+  - defusedxml          # hardened XML parsing for scripts/europepmc_fulltext.py
   - pip:
     - requests>=2.28

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -509,7 +509,10 @@ def _unpaywall_save_dir(out_path: Path, parsed_type: str, pmid: str | None, doi:
     按输入类型决定保存目录：PMID/PubMed URL → pdf/{PMID}/；DOI 或 doi.org 链接 → pdf/{sanitized_doi}/。
     """
     if parsed_type == "pmid" and pmid:
-        return out_path / pmid
+        # Sanitize the PMID before using it as a path component to guard against
+        # path traversal (e.g. "../"); PMIDs are plain integers in practice.
+        safe_pmid = pmid.replace("/", "_").replace("\\", "_").replace("..", "_").strip()
+        return out_path / safe_pmid
     return out_path / _doi_to_subdir_name(doi)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ sdrf-pipelines[ontology]
 
 # Tools dependencies (tools/ package)
 requests>=2.28
+# Hardened XML parsing for scripts/europepmc_fulltext.py (XXE / entity-expansion safe)
+defusedxml>=0.7

--- a/scripts/europepmc_fulltext.py
+++ b/scripts/europepmc_fulltext.py
@@ -28,6 +28,13 @@ import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+try:
+    # Hardened parser: protects against XML entity-expansion / XXE attacks.
+    from defusedxml.ElementTree import fromstring as _safe_fromstring
+except ImportError:  # pragma: no cover - fallback when defusedxml is unavailable
+    _safe_fromstring = ET.fromstring
 
 
 EUROPE_PMC_BASE = "https://www.ebi.ac.uk/europepmc/webservices/rest"
@@ -36,7 +43,7 @@ DEFAULT_TIMEOUT = 120
 XLINK_HREF = "{http://www.w3.org/1999/xlink}href"
 
 PMCID_RE = re.compile(r"^PMC\d+$", re.IGNORECASE)
-PMID_RE = re.compile(r"^\d{5,}$")
+PMID_RE = re.compile(r"^\d+$")  # PMIDs are positive integers of any length
 DOI_RE = re.compile(r"^10\.\S+/\S+$", re.IGNORECASE)
 HTTP_URL_RE = re.compile(r"https?://[^\s<>()\[\]{}\"']+", re.IGNORECASE)
 
@@ -338,7 +345,18 @@ def read_xml_source(
     normalized_identifier, inferred_type = normalize_identifier_input(identifier)
     resolved_type = id_type or inferred_type or detect_id_type(normalized_identifier)
     record = resolve_article(normalized_identifier, resolved_type)
-    xml_text = fetch_text(f"{EUROPE_PMC_BASE}/{record['resolvedPmcid']}/fullTextXML")
+    pmcid = record["resolvedPmcid"]
+    try:
+        xml_text = fetch_text(f"{EUROPE_PMC_BASE}/{pmcid}/fullTextXML")
+    except HTTPError as exc:
+        if exc.code == 404:
+            raise SystemExit(
+                f"No full-text XML available for {pmcid} "
+                "(the article may not be in the Europe PMC open-access subset)."
+            )
+        raise SystemExit(f"Failed to fetch full-text XML for {pmcid}: HTTP {exc.code}")
+    except URLError as exc:
+        raise SystemExit(f"Network error fetching full-text XML for {pmcid}: {exc.reason}")
     return xml_text, record
 
 
@@ -718,9 +736,7 @@ def extract_metadata(root: ET.Element, record: dict) -> dict:
         "publication_date": publication_date
         or str(record.get("firstPublicationDate") or ""),
         "authors": authors
-        or [record.get("authorString", "")]
-        if record.get("authorString")
-        else authors,
+        or ([record["authorString"]] if record.get("authorString") else []),
         "pmcid": article_ids.get("pmcid")
         or record.get("resolvedPmcid")
         or record.get("pmcid", ""),
@@ -1011,7 +1027,7 @@ def main() -> None:
     args = parse_args()
     id_type = None if args.id_type == "auto" else args.id_type
     xml_text, record = read_xml_source(args.identifier, id_type, args.xml_file)
-    root = ET.fromstring(xml_text)
+    root = _safe_fromstring(xml_text)
     payload = build_payload(root, record)
     payload = filter_sections(payload, args.section)
 


### PR DESCRIPTION
## Summary

Improvements surfaced by a CodeRabbit review of the repo. Two themes: **documentation accuracy** and **safe code hardening**. No behavior changes to the skills themselves.

## Documentation
The repo now ships **18 user-invocable skills**, but the docs were stale (14–16) and missing some entries. Corrected counts and added the missing skills across every platform doc:

| File | Before | After | Added entries |
|------|:------:|:-----:|---------------|
| `README.md` | 16 | 18 | `metascreen`, `autoresearch` |
| `CLAUDE.md` | 16 | 18 | `metascreen` |
| `.opencode/AGENTS.md` | 14 | 18 | `metascreen`, `autoresearch`, `cellline` |
| `GEMINI.md` | 15 | 18 | `metascreen`, `autoresearch`, `cellline` |

- `GEMINI.md` also gains the reserved-words and validate-before-present rules for parity with `CLAUDE.md`.

## Code hardening
- **`scripts/europepmc_fulltext.py`**
  - Parse XML via `defusedxml` (XXE / entity-expansion safe) with a graceful fallback to the stdlib parser.
  - `PMID_RE` now accepts PMIDs of any length (`\d+` instead of `\d{5,}`, which rejected valid short PMIDs).
  - Surface friendly errors on HTTP 404 / network failure instead of a raw traceback.
  - Clarify the ambiguous `authors` operator-precedence expression.
- **`mcp/server.py`** — sanitize the PMID before using it as a path component (path-traversal guard), matching the existing DOI handling.
- **`.github/workflows/check-spec.yml`** — use a full `https://` URL in the step-summary link so it resolves.
- Add `defusedxml` to `requirements.txt` and `environment.yml`.

## Verification
- `python -m py_compile` passes for both edited Python files.
- CLI smoke test (`europepmc_fulltext.py --help`) works; `defusedxml` import path active.
- PMID regex, `authors` logic, and edited YAML validated locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new skills: study screening/shortlisting and autoresearch workflows.
  * Added cell-line lookup capability via Cellosaurus integration.

* **Bug Fixes**
  * Enhanced XML parsing security with hardened parsing library.
  * Improved error handling for missing content requests.
  * Fixed path traversal vulnerability in directory handling.
  * Corrected output link format to fully qualified URLs.

* **Chores**
  * Updated documentation reflecting 18 available skills.
  * Added security-focused XML parsing dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->