### PR TITLE
Section C of #35: OLS smart-mode ambiguity, getChildren descendants, annotator guidance

### DIFF
--- a/mcp/server.py
+++ b/mcp/server.py
@@ -708,6 +708,43 @@ def _search_all_ontologies(query: str, page_size: int, exact: bool) -> dict:
     }
 
 
+def _smart_search(searcher, page_size: int) -> dict:
+    """Exact-first search that refuses to present a non-exact / one-of-many hit
+    as if it were THE answer (issue #35 C4).
+
+    Previously smart mode probed exact with ``page_size=1`` and collapsed
+    ``numFound`` to 1, so ``HeLa`` → ``HeLa-MAGI-CCR5`` (a synonym-matched
+    *different* entity) came back looking authoritative. Here we probe exact
+    **wide**: if more than one *distinct accession* matches the query exactly
+    (label or synonym), we return them all with ``ambiguous: true`` so the
+    caller must disambiguate rather than trust a single hit. Only a single
+    distinct exact match is returned as confident; otherwise we fall back to
+    fuzzy (flagged ``fallback: "fuzzy"``).
+
+    ``searcher(page_size, exact) -> dict`` runs one OLS query and returns a dict
+    carrying ``results`` (each ``{label, accession, ontology}``).
+    """
+    probe = min(max(page_size, 10), 50)
+    hit = searcher(probe, True)
+    results = hit.get("results", [])
+    distinct = {r.get("accession") for r in results if r.get("accession")}
+    if distinct:
+        hit["numFound"] = len(results)
+        if len(distinct) > 1:
+            hit["ambiguous"] = True
+            hit["note"] = (
+                "Multiple distinct terms match this query exactly (label or "
+                "synonym). This is NOT a single authoritative hit — verify which "
+                "entity is intended (e.g. parental cell line vs a derivative, the "
+                "drug vs a regimen) before citing an accession."
+            )
+        return hit
+    fuzzy = searcher(page_size, False)
+    fuzzy["numFound"] = len(fuzzy.get("results", []))
+    fuzzy["fallback"] = "fuzzy"
+    return fuzzy
+
+
 @mcp.tool()
 def searchClasses(
     query: str,
@@ -723,16 +760,23 @@ def searchClasses(
     xlmod, go.
 
     mode (default "smart"):
-      - "smart" : try EXACT label/synonym first; if a hit exists, return JUST
-                  that single exact match (page_size is ignored). Only when
-                  nothing matches exactly, fall back to fuzzy top-`page_size`
-                  (default 3). This keeps downstream reasoning uncluttered.
+      - "smart" : EXACT label/synonym first, probed WIDE. A single distinct
+                  exact match is returned as confident; if several *distinct*
+                  terms match exactly (e.g. a cell line and its derivatives),
+                  all are returned with `ambiguous: true` so you disambiguate
+                  rather than trust one hit. Only when nothing matches exactly
+                  does it fall back to fuzzy top-`page_size`.
       - "exact" : exact-only, cap results at page_size. Returns empty on miss.
       - "fuzzy" : fuzzy-only, returns top-`page_size` regardless of exact hits.
 
+    NOTE: for controlled identifiers where a query commonly names several
+    entities — cell lines (`HeLa`), drugs (`methotrexate`), anatomy
+    (`hippocampus`) — prefer `mode="fuzzy"` and eyeball the candidates; smart
+    mode's exact probe can surface a synonym-matched *different* entity.
+
     Returns {query, ontology_id, numFound, results:[{label, accession, ontology}]}.
-    When smart mode falls back to fuzzy, the returned dict carries
-    `fallback: "fuzzy"` so callers can tell the match is not exact.
+    `fallback: "fuzzy"` marks a non-exact result; `ambiguous: true` marks
+    several distinct exact matches (not a single authoritative hit).
     """
     m = (mode or "smart").lower().strip()
     if m == "exact":
@@ -740,17 +784,10 @@ def searchClasses(
     if m == "fuzzy":
         return _search_ontology_classes(query, ontologyId, page_size, exact=False)
 
-    # smart: exact first (single), fuzzy top-N fallback
-    exact_hit = _search_ontology_classes(query, ontologyId, page_size=1, exact=True)
-    if exact_hit.get("results"):
-        # Align numFound with the slice we actually return, so the AI reads
-        # `numFound == len(results)` as "this IS the exact answer".
-        exact_hit["numFound"] = len(exact_hit["results"])
-        return exact_hit
-    fuzzy = _search_ontology_classes(query, ontologyId, page_size, exact=False)
-    fuzzy["numFound"] = len(fuzzy.get("results", []))
-    fuzzy["fallback"] = "fuzzy"
-    return fuzzy
+    return _smart_search(
+        lambda ps, ex: _search_ontology_classes(query, ontologyId, ps, exact=ex),
+        page_size,
+    )
 
 
 # --- 4.1 Search OLS across ALL ontologies (no filter) ---
@@ -762,12 +799,15 @@ def search(query: str, page_size: int = 3, mode: str = "smart") -> dict:
     ontology is unknown.
 
     mode (default "smart"):
-      - "smart" : exact-first (single hit), fuzzy top-`page_size` fallback.
+      - "smart" : exact-first probed WIDE; a single distinct exact match is
+                  confident, several distinct exact matches come back with
+                  `ambiguous: true`, else fuzzy top-`page_size` fallback.
       - "exact" : exact-only, cap at page_size. Empty on miss.
       - "fuzzy" : fuzzy-only, returns top-`page_size`.
 
     Returns {query, numFound, results:[{label, accession, ontology}]}.
-    Carries `fallback: "fuzzy"` when smart mode falls back.
+    `fallback: "fuzzy"` marks a non-exact result; `ambiguous: true` marks
+    several distinct exact matches (not a single authoritative hit).
     """
     m = (mode or "smart").lower().strip()
     if m == "exact":
@@ -775,14 +815,9 @@ def search(query: str, page_size: int = 3, mode: str = "smart") -> dict:
     if m == "fuzzy":
         return _search_all_ontologies(query, page_size, exact=False)
 
-    exact_hit = _search_all_ontologies(query, page_size=1, exact=True)
-    if exact_hit.get("results"):
-        exact_hit["numFound"] = len(exact_hit["results"])
-        return exact_hit
-    fuzzy = _search_all_ontologies(query, page_size, exact=False)
-    fuzzy["numFound"] = len(fuzzy.get("results", []))
-    fuzzy["fallback"] = "fuzzy"
-    return fuzzy
+    return _smart_search(
+        lambda ps, ex: _search_all_ontologies(query, ps, ex), page_size
+    )
 
 
 # --- 4.2 Get children of an ontology term (specificity check) ---
@@ -833,13 +868,21 @@ def _resolve_ols_term(accession: str) -> tuple[str, str] | None:
 
 
 @mcp.tool()
-def getChildren(accession: str, rows: int = 20) -> dict:
+def getChildren(accession: str, rows: int = 100) -> dict:
     """
-    Get direct child terms for an ontology accession (e.g. 'MONDO:0004992').
-    Useful for specificity checks: if a term has many specific children, prefer
-    a more specific child term in the SDRF characteristic.
+    Get the **descendant** terms (transitive children) of an ontology accession
+    (e.g. 'PRIDE:0000895'). Useful for specificity / enumeration checks.
+
+    Returns descendants, not just direct children (issue #35 B7): OLS's own
+    `/children` returns only the immediate level, so `getChildren(PRIDE:0000895)`
+    would omit `pooled` / `empty` / `bulk control` — genuine descendants reached
+    via an intermediate node — and an annotator that trusted it would force
+    `not applicable` onto valid rows. The validator's `examples` treat these
+    grandchildren as members, so "children" here means *descendant*.
+
     Falls back to OLS /search for ontologies not in the static IRI map.
-    Returns: accession, count, children [{label, accession, ontology}].
+    Returns: accession, count, children [{label, accession, ontology}]
+    (`children` key kept for backward compatibility; entries are descendants).
     """
     parsed = _accession_to_ols_iri(accession)
     if parsed is None:
@@ -851,12 +894,12 @@ def getChildren(accession: str, rows: int = 20) -> dict:
     ont_id, iri = parsed
     encoded_iri = urllib.parse.quote(urllib.parse.quote(iri, safe=""))
     data = _cached_get_json(
-        f"{OLS_BASE}/ontologies/{ont_id}/terms/{encoded_iri}/children",
+        f"{OLS_BASE}/ontologies/{ont_id}/terms/{encoded_iri}/descendants",
         params={"size": rows},
     )
     if not data:
         return {"accession": accession, "count": 0, "children": [],
-                "error": "No children or lookup failed"}
+                "error": "No descendants or lookup failed"}
     terms = data.get("_embedded", {}).get("terms", []) or []
     children = []
     for t in terms:

--- a/skills/sdrf-adversarial-review/SKILL.md
+++ b/skills/sdrf-adversarial-review/SKILL.md
@@ -18,6 +18,14 @@ polish or extend it. Approve only what the artifact and cited evidence support.
 4. If context isolation cannot be established, return `REVIEW_UNAVAILABLE` and
    do not create a passing receipt.
 5. Do not edit the SDRF. Return findings to the producer.
+6. Read only files scoped to this artifact's accession. When reviewers run
+   concurrently, a shared scratchpad with generic filenames (`files_all.json`,
+   `efetch.xml`, `mmc*.xlsx`) silently substitutes one dataset's data for
+   another's — the file still parses, it just describes a different PXD. Read
+   from `scratchpad/<PXD>/` only, and assert on read: every fetched file
+   list's `projectAccessions`, and every supplementary/`efetch` result's
+   returned title/accession, must match the artifact's accession before you use
+   it — verify identity, not just HTTP 200.
 
 Read [references/review-contract.md](references/review-contract.md) before
 writing the report or recording approval.

--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -10,6 +10,29 @@ argument-hint: "[PXD accession or experiment description]"
 You are performing a complete SDRF annotation. Follow these steps IN ORDER.
 Do not skip steps. Do not guess — use MCP tools to verify everything.
 
+## Step 0a: Isolate this dataset's working files (required)
+
+When annotators run concurrently they collide through a **shared scratchpad**:
+generic filenames (`files_all.json`, `build.py`, `efetch.xml`) written by several
+agents into one directory silently overwrite each other. The failure is silent —
+the file still parses, it just describes a *different* dataset — so an agent that
+trusts the re-read annotates the wrong PXD. This has happened (a cached PRIDE file
+list overwritten mid-run with another accession's data; an `efetch.xml` replaced
+by an unrelated paper).
+
+1. Derive your working directory from the accession — `scratchpad/<PXD>/` — and
+   write **every** temp file there and nowhere else.
+2. Never read a scratch file you did not write in **this** run.
+3. Point PDF/full-text fetchers at that directory
+   (`get_pdf_by_unpaywall(output_dir="scratchpad/<PXD>/")`); `mcp/pdf/` is shared
+   by default and two agents fetching different papers will collide.
+4. **Assert on read anyway** (defence in depth — the substitution also comes from
+   outside): after fetching the file list, check every entry's `projectAccessions`
+   contains your accession; when you pull supplementary files or an `efetch`
+   result, verify the returned **title/accession**, not just HTTP 200. (Europe
+   PMC `supplementaryFiles` has returned another paper's `mmc*.xlsx`; `efetch`
+   with `id=PMC…` silently returns a different article — use the numeric id.)
+
 ## Step 0: Check parse_sdrf availability
 
 Before starting, verify that `parse_sdrf` is available (run `parse_sdrf --version` or `which parse_sdrf`). If it is not installed:
@@ -38,6 +61,27 @@ Europe PMC. You do NOT need a separate identifier-conversion tool.
 The sample/data processing protocols are submitter-authored free text and are
 often the highest-signal source for enzyme, modifications, tolerances, labeling,
 and instrument acquisition — read them BEFORE the publication.
+
+> **PRIDE's structured fields are NOT ground truth — trust them last.**
+> Precedence for any disputed value is **raw data > paper Methods > PRIDE fields**.
+> Across a 26-dataset audit, `get_project_details` was wrong repeatedly:
+> - `instruments` off by model/variant (HF vs **HF-X**; LTQ Orbitrap Velos vs
+>   **Velos Pro**; LTQ Orbitrap Elite vs **Fusion Lumos**; Q Exactive vs
+>   **Q Exactive Plus**) — and sometimes the structured field contradicted the
+>   free-text protocol *in the same record*.
+> - `modifications` routinely said "No PTMs are included in the dataset" while the
+>   paper listed several.
+>
+> When a value matters, recover it from the primary sources instead of trusting the field:
+> - **Instrument model** — HTTP-range-read the first ~256 KB of a Thermo `.raw`
+>   (utf-16-le); the model string is in the header. Bruker `.d` →
+>   `analysis.tdf` is a SQLite DB (see the Bruker skill, #33).
+> - **Search settings & the channel→sample map** — deposited search outputs beat
+>   Methods prose: MaxQuant `summary.txt`/`parameters.txt`, FragPipe
+>   `fragger.params`, DIA-NN logs, PD `.msf` (SQLite). These are often the *only*
+>   source of the channel map.
+> - **Run names inside huge archives** — read the ZIP central directory via an
+>   HTTP range request rather than downloading a multi-GB archive.
 
 ### 1.2 Get the file list
 ```text
@@ -76,6 +120,16 @@ alone.
 ### 1.3 Find and read the publication
 
 For each record in `publications` (Step 1.1), pick exactly ONE tool:
+
+> **`is_open_access` is unreliable — a `false` means "try harder", not "abstract
+> only".** Both PRIDE and Europe PMC reported a gold-OA CC-BY paper as
+> `is_open_access: false`; Europe PMC has returned anti-bot HTML while reporting
+> `oa_status: green`, and `fullTextXML` sometimes 404s for papers that are in
+> fact open. Before falling back to abstract-only (branch b), exhaust the
+> recovery routes: Unpaywall (by DOI), the PMC HTML render, NCBI eutils, and a
+> Europe PMC free-text search on the **accession itself**. Several datasets'
+> entire Methods — hence cell line, channel map, instrument — hung on not
+> believing this flag.
 
 ```text
 a. pmcid is set AND is_open_access == true:
@@ -278,16 +332,29 @@ For clean SDRF-like values, lexical exact or synonym matches are the default pat
 
 **Smart mode is the default** (do NOT pass `mode` unless you need to override):
 
-1. The tool first tries an **exact** label/synonym match.
-   - If exactly one hit → returns ONLY that record. Use its accession directly.
+1. The tool tries an **exact** label/synonym match, probed wide.
+   - Exactly one *distinct* term → returns it. Use its accession directly.
+   - Several distinct terms match exactly → the response carries
+     `ambiguous: true` and lists them. This is NOT a single answer — pick the
+     intended entity yourself (see the trap table below), do not grab the first.
 2. If there is no exact hit → the tool falls back to **fuzzy top-3**
    and tags the response with `fallback: "fuzzy"`.
    - Pick the best candidate. If none fit, refine the query (correct typos,
      try a synonym, or switch to a more specific ontology) and search again.
 
+> **For controlled identifiers that a query commonly over-matches — cell lines
+> (`HeLa`), drugs (`methotrexate`), anatomy (`hippocampus`) — do not trust a
+> single smart-mode hit.** In an audit, smart mode returned confident *wrong*
+> single hits: `HeLa` → `HeLa-MAGI-CCR5`, `A549` → `A549-CR` (a resistant
+> derivative), `methotrexate` → `High-dose Methotrexate/Rituximab Regimen`,
+> `hippocampus` → `CA1 field of hippocampus`, and `in vitro maturation` →
+> unrelated terms for a concept with *no* OLS term. For these, pass
+> `mode="fuzzy"` and eyeball the candidates against the intended entity.
+
 Override only when necessary:
 - `mode="exact"` — force exact-only (e.g. strict validation); empty on miss.
-- `mode="fuzzy"` — force fuzzy top-N; use when exploring close neighbours.
+- `mode="fuzzy"` — force fuzzy top-N; use for cell lines/drugs/anatomy and when
+  exploring close neighbours.
 
 ### 4.3 Use embeddings and ZOOMA only when needed
 Trigger OLS embedding search when:
@@ -420,6 +487,25 @@ Column 3: NT=Acetyl;AC=UNIMOD:1;PP=Protein N-term;MT=Variable
 **Double-check**: UNIMOD:1 = Acetyl, UNIMOD:21 = Phospho. Most common swap!
 For TMT: UNIMOD:737 (TMT6/10/11plex) or UNIMOD:2016 (TMTpro 16/18plex)
 
+**Domain traps — verify, don't reflex** (each is validator-clean when wrong):
+- **Dimethyl**: OLS returns `UNIMOD:510` for "Dimethyl" — that is
+  `Dimethyl:2H(4)13C(2)` (+6). The plain light label is `UNIMOD:36`; heavy **+8
+  is `UNIMOD:330`**. Match the mass to the labelling scheme; don't take the first hit.
+- **Carbamidomethyl requires an alkylation step.** Do NOT assert
+  `NT=Carbamidomethyl;AC=UNIMOD:4` when the protocol explicitly omits
+  reduction/alkylation — it is then wrong on every row (and passes validation).
+  When the deposited search params and the paper's Methods disagree, the search
+  params win (precedence: raw > Methods > PRIDE).
+- **Cell-line identity is a research task, not a lookup.** Pierce HeLa digest
+  standard is **HeLa S3** (`CVCL_0058`), not parental HeLa (`CVCL_0030`);
+  ATCC-purchased Jurkat is the **E6-1 clone** (`CVCL_0367`), not the naive
+  `CVCL_0065`. Both wrong answers are validator-clean — confirm against the
+  vendor's page, not just the name.
+- **"Single-cell-equivalent" is a mass, not a count.** `0.5 ng ≈ 2–3 cells` is a
+  dilution standard; annotate the mass, not `cells per well = 2`.
+- **`developmental stage` is the DONOR's stage**, not a cell's maturation state
+  (e.g. not an oocyte's IVM state) — the obvious-looking column is the wrong one.
+
 ### 5.3 Cleavage agent
 ```text
 searchClasses(query="Trypsin", ontologyId="ms")
@@ -431,10 +517,23 @@ Format: NT=Trypsin;AC=MS:1001251
 - TMT: `TMT126`, `TMT127N`, `TMT127C`, etc. (one row per channel per file)
 - SILAC: `SILAC light`, `SILAC heavy`
 
-### 5.5 Acquisition method
-Use PRIDE ontology terms:
-- `Data-Dependent Acquisition`
-- `Data-Independent Acquisition`
+### 5.5 Acquisition method (PRIDE-first — required)
+Column: `comment[proteomics data acquisition method]`
+
+1. Look up terms under parent **`PRIDE:0000659`** (Proteomics data acquisition method)
+   in the **PRIDE** ontology (OLS children/descendants of that parent).
+2. Prefer PRIDE over PSI-MS for this column whenever a PRIDE child exists.
+3. Write the **canonical case-sensitive** `NT=…;AC=…` form (labels must match OLS):
+
+| Mode | Value |
+|------|--------|
+| DDA | `NT=Data-dependent acquisition;AC=PRIDE:0000627` |
+| DIA (incl. SWATH / diaPASEF flavours) | `NT=Data-independent acquisition;AC=PRIDE:0000450` |
+| SRM / MRM | `NT=Selected reaction monitoring;AC=PRIDE:0000630` |
+| PRM | `NT=Parallel reaction monitoring;AC=PRIDE:0000629` |
+
+Do **not** write plain text, `NT=`-only, or PSI-MS accessions (e.g. `MS:1000206`) for
+this column when the PRIDE term above applies.
 
 ### 5.6 Verify technical metadata with raw file analysis (recommended)
 If the dataset has raw files available (PRIDE or local), recommend using **techsdrf**

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -107,3 +107,92 @@ class TestGetProjectFiles:
         assert result["rawfile_count"] == 0
         assert result["raw_file_names"] == []
         assert "error" in result
+
+
+def _ols_search_response(obo_ids, num_found=None):
+    """Build a minimal OLS /search JSON body from a list of obo_ids."""
+    docs = [
+        {"label": oid.split(":")[0].lower(), "obo_id": oid, "ontology_prefix": oid.split(":")[0]}
+        for oid in obo_ids
+    ]
+    return {"response": {"numFound": num_found if num_found is not None else len(docs), "docs": docs}}
+
+
+class TestSmartSearchAmbiguity:
+    """issue #35 C4 — smart mode must not present a non-exact / one-of-many hit
+    as if it were THE answer."""
+
+    def test_multiple_distinct_exact_matches_flagged_ambiguous(self):
+        """`HeLa` exact-matches several distinct entities → ambiguous, not a
+        confident single hit."""
+        mcp_server = _mcp_server
+        # exact probe returns two DIFFERENT accessions (parental + derivative)
+        resp = _ols_search_response(["EFO:0001185", "CLO:0003724"])
+        with patch.object(mcp_server, "_cached_get_json", return_value=resp):
+            out = mcp_server.searchClasses("HeLa", "efo")  # default mode="smart"
+        assert out.get("ambiguous") is True
+        assert out["numFound"] == 2
+        assert "note" in out
+        assert {r["accession"] for r in out["results"]} == {"EFO:0001185", "CLO:0003724"}
+
+    def test_single_distinct_exact_match_is_confident(self):
+        """A single distinct exact match returns confidently, no ambiguous flag."""
+        mcp_server = _mcp_server
+        resp = _ols_search_response(["NCBITaxon:562"])
+        with patch.object(mcp_server, "_cached_get_json", return_value=resp):
+            out = mcp_server.searchClasses("Escherichia coli", "ncbitaxon")
+        assert out.get("ambiguous") is None
+        assert out.get("fallback") is None
+        assert out["numFound"] == 1
+
+    def test_falls_back_to_fuzzy_when_no_exact(self):
+        """No exact match → fuzzy fallback, flagged so the caller knows it's not exact."""
+        mcp_server = _mcp_server
+
+        def side_effect(url, params=None, timeout=None):
+            if params and params.get("exact") == "true":
+                return _ols_search_response([])          # exact miss
+            return _ols_search_response(["UBERON:0002421"])  # fuzzy hit
+
+        with patch.object(mcp_server, "_cached_get_json", side_effect=side_effect):
+            out = mcp_server.searchClasses("hippocampus", "uberon")  # typo → no exact
+        assert out.get("fallback") == "fuzzy"
+        assert out.get("ambiguous") is None
+        assert out["numFound"] == 1
+
+    def test_exact_probe_is_wide_not_one(self):
+        """The exact probe must request more than 1 row, or ambiguity is invisible."""
+        mcp_server = _mcp_server
+        captured = []
+
+        def side_effect(url, params=None, timeout=None):
+            captured.append(params or {})
+            return _ols_search_response(["EFO:0001185"])
+
+        with patch.object(mcp_server, "_cached_get_json", side_effect=side_effect):
+            mcp_server.searchClasses("HeLa", "efo")
+        assert captured, "no OLS call made"
+        assert captured[0].get("rows", 0) > 1, "exact probe capped at 1 hides ambiguity"
+
+
+class TestGetChildrenDescendants:
+    """issue #35 B7 — getChildren must return descendants, not only direct children."""
+
+    def test_uses_descendants_endpoint(self):
+        mcp_server = _mcp_server
+        captured_urls = []
+
+        def side_effect(url, params=None, timeout=None):
+            captured_urls.append(url)
+            return {"_embedded": {"terms": [
+                {"label": "pooled sample", "obo_id": "PRIDE:0000544", "ontology_prefix": "PRIDE"},
+                {"label": "empty", "obo_id": "PRIDE:0000562", "ontology_prefix": "PRIDE"},
+            ]}}
+
+        with patch.object(mcp_server, "_cached_get_json", side_effect=side_effect):
+            out = mcp_server.getChildren("PRIDE:0000895")
+        assert captured_urls, "no OLS call made"
+        assert captured_urls[0].endswith("/descendants")
+        assert "/children" not in captured_urls[0]
+        assert out["count"] == 2
+        assert {c["accession"] for c in out["children"]} == {"PRIDE:0000544", "PRIDE:0000562"}

--- a/tools/ols_client.py
+++ b/tools/ols_client.py
@@ -187,8 +187,15 @@ class OLSClient:
     # Hierarchy navigation
     # ------------------------------------------------------------------
 
-    def get_children(self, accession: str, rows: int = 20) -> list[OLSTerm]:
-        """Get child terms for specificity checks."""
+    def get_children(self, accession: str, rows: int = 100) -> list[OLSTerm]:
+        """Get **descendant** terms (transitive children) for specificity /
+        enumeration checks.
+
+        Uses OLS `/descendants`, not `/children` (issue #35 B7): `/children`
+        returns only the immediate level, so descendants reached via an
+        intermediate node (e.g. `pooled`/`empty`/`bulk control` under
+        `PRIDE:0000895`) would be missed. The validator's `examples` treat such
+        grandchildren as members, so "children" here means *descendant*."""
         ontology_id, _ = self._split_accession(accession)
         iri = self._accession_to_iri(accession, ontology_id or "")
         if not iri or not ontology_id:
@@ -196,7 +203,7 @@ class OLSClient:
         encoded_iri = urllib.parse.quote(urllib.parse.quote(iri, safe=""))
         try:
             data = self._get(
-                f"/ontologies/{ontology_id.lower()}/terms/{encoded_iri}/children",
+                f"/ontologies/{ontology_id.lower()}/terms/{encoded_iri}/descendants",
                 params={"size": rows},
             )
         except requests.HTTPError:


### PR DESCRIPTION
Resolves the **skills/tooling** slice (section C) of umbrella **#35**, tracked in **#44**.
C1 already shipped in #43; this covers the rest.

## Code fixes (tested)

**C4 — OLS smart mode no longer presents a non-exact / one-of-many hit as authoritative.**
The exact probe used `page_size=1` and then set `numFound = 1`, so a query that matches several
distinct entities by label/synonym (`HeLa` → `HeLa-MAGI-CCR5`, `A549` → `A549-CR`,
`methotrexate` → a treatment regimen) came back looking like *the* answer. `searchClasses` and
`search` now share a `_smart_search` helper that probes exact **wide**:
- one distinct accession → returned confidently (as before);
- several distinct accessions → returned with **`ambiguous: true`** + a `note`, so the caller
  disambiguates instead of grabbing the first;
- no exact match → fuzzy fallback (`fallback: "fuzzy"`, unchanged).

**B7 — `getChildren` returns descendants, not just direct children.**
`getChildren` / `ols_client.get_children` now hit OLS `/descendants` instead of `/children`, so
transitive members (`pooled` / `empty` / `bulk control` under `PRIDE:0000895`) are no longer
silently dropped — an annotator trusting the old output would have forced `not applicable` onto
valid rows. The `children` return key is kept for backward compatibility.

## Skill guidance (no behaviour change, but this is the actual product)

- **C2** `sdrf-annotate` Step 1.1 — PRIDE structured fields are not ground truth; precedence
  **raw > paper Methods > PRIDE fields**, with recovery routes (HTTP-range-read `.raw` headers for
  the instrument model, deposited search outputs for the channel→sample map, ZIP central directory
  via range).
- **C3** Step 1.3 — `is_open_access` is unreliable in PRIDE *and* Europe PMC; a `false` means
  "try harder" (Unpaywall / PMC HTML / eutils / EPMC accession search), not "abstract only".
- **C4/C5** Step 4.2 / 5.2 — prefer `mode="fuzzy"` for cell lines/drugs/anatomy; a domain-traps
  block (Dimethyl **UNIMOD:330** vs 510, carbamidomethyl requires an alkylation step, cell-line
  identity is a research task, "single-cell-equivalent" is a mass, `developmental stage` = donor).
- **C6** per-accession scratchpad (`scratchpad/<PXD>/`) + **assert-on-read** in both `sdrf-annotate`
  and `sdrf-adversarial-review`, so concurrent agents can't silently annotate the wrong dataset.

## Tests
8 new tests in `tests/test_mcp_server.py` (smart-mode ambiguity/confidence/fuzzy-fallback/wide-probe
+ getChildren-uses-descendants). Full suite **147 passing**; no new lint vs main.

## Out of scope (other repos, tracked separately)
- Section **A** (validator: accession existence + `allow_*` enforcement, CL case-sensitivity) →
  bigbio/sdrf-pipelines#321
- Section **B** (templates: cell-line flag deadlock, DDA/DIA, undeliverable columns) →
  bigbio/sdrf-templates#51

Closes #44.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved ontology search with more reliable exact-match detection, ambiguity handling, and fuzzy-search fallback.
  - Ontology term browsing now includes transitive descendants, with up to 100 results by default.

- **Bug Fixes**
  - Improved validation of retrieved project files and metadata.
  - Added safeguards for interpreting experimental annotations, modifications, instruments, and acquisition methods.

- **Documentation**
  - Updated SDRF review and annotation guidance for more thorough data, publication, and ontology verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->