### PR TITLE
Stop and audit when a dataset is already annotated (new /sdrf:annotate Step 0.5 gate + audit tool)

### DIFF
--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -17,6 +17,88 @@ Before starting, verify that `parse_sdrf` is available (run `parse_sdrf --versio
 - Suggest `/sdrf:setup` or `conda env create -f environment.yml && conda activate sdrf-skills` (or `pip install -r requirements.txt`)
 - Offer to continue with manual checks only, or wait for the user to install and retry
 
+## Step 0.5: Check whether the dataset is ALREADY annotated — STOP GATE
+
+**Do this before any annotation work.** Annotating a dataset that is already
+annotated is not free: if the existing file is fine you have wasted the effort and
+produced a noisy diff, and if it is wrong you may ship a second annotation beside
+it without anyone noticing the first was broken.
+
+### 0.5.1 Look it up in the community repository
+
+```bash
+gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD}/{PXD}.sdrf.tsv \
+  --jq .download_url 2>/dev/null || echo "new"
+```
+
+Check the **community repository**, which is authoritative. A local
+`spec/annotated-projects/` copy may be stale, so do not rely on it alone.
+
+**If it does not exist** → this is a new annotation. Continue to Step 1 normally.
+
+**If it exists → STOP. Do not annotate yet.** Go to 0.5.2.
+
+### 0.5.2 Audit the existing annotation
+
+Never assume the existing file is right, and never assume it is wrong. Fetch it
+and audit it against the deposit:
+
+```bash
+curl -sL "$(gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD}/{PXD}.sdrf.tsv --jq .download_url)" -o existing.sdrf.tsv
+python -m tools audit-existing existing.sdrf.tsv --accession {PXD} \
+  --runs deposited_runs.txt --organism "<each organism PRIDE registers>"
+```
+
+The audit is mechanical and checks only what the deposit can settle:
+
+| Check | Severity | Catches |
+|---|---|---|
+| `missing_runs` / `invented_runs` | blocker | annotation does not match the deposited files |
+| `organism_mismatch` | blocker | organisms PRIDE registers that never appear in the SDRF |
+| `counter_abuse` | major | `technical replicate` / `fraction identifier` used as a row index |
+| `cv_term_no_accession` | major | `NT=` with no `AC=` |
+| `no_factor_value` | major | no factor value column declared |
+| `characteristics_not_bare_label`, `source_name_convention` | minor | convention drift |
+
+Also run `parse_sdrf validate-sdrf` on the existing file — a file can be valid and
+still be wrong about the deposit, so the two checks are complementary.
+
+`--runs` and `--organism` are optional, and when omitted the corresponding checks
+are **skipped, not passed**. Supply them whenever you have them, and say which
+checks were skipped when reporting.
+
+### 0.5.3 Report and let the USER decide
+
+Present the finding and stop. Do not pick for them:
+
+```text
+{PXD} is already annotated in the community repository ({N} rows).
+
+Audit result: {clean | N issues}
+{rendered findings, most severe first}
+
+How would you like to proceed?
+  - leave        - the existing annotation is adequate; do nothing
+  - fix          - open a PR addressing ONLY the defects above
+  - reannotate   - rebuild from scratch and open a PR replacing the file
+```
+
+Choose what to *recommend* by defect class, and say why:
+
+- **no findings** → recommend `leave`. Re-annotating a correct file produces
+  churn for reviewers and risks regressing curation someone did by hand.
+- **only major/minor findings** → recommend `fix`. A targeted diff is far easier
+  to review than a wholesale replacement, and it preserves existing work.
+- **any blocker** → recommend `reannotate`. When the file misrepresents which
+  runs or which organisms the deposit contains, patching individual cells tends
+  to leave the underlying structure wrong.
+
+**Never re-annotate silently, and never overwrite an existing annotation without
+the user explicitly choosing `reannotate`.** If the user does choose it, continue
+to Step 1 and treat the result as an **update** to an existing dataset: the PR must
+say what was wrong with the previous annotation and cite the evidence, so a
+reviewer can check the claim rather than take it on trust.
+
 ## Step 1: Gather Project Context
 
 If a **PXD accession** is provided:
@@ -529,7 +611,9 @@ Present the validated SDRF as a TSV code block and explain:
 
 If the annotation was for a **ProteomeXchange dataset** (PXD accession):
 
-1. Check if this PXD already exists in `spec/annotated-projects/{PXD}/`
+1. You already established in **Step 0.5** whether this PXD exists in the
+   community repository — reuse that result rather than checking again, and do
+   not fall back to `spec/annotated-projects/`, which can be stale.
 2. Tell the user their annotation can be contributed to the community:
 
 ```text
@@ -544,12 +628,17 @@ for ProteomeXchange datasets. Contributing your annotation means:
 Run /sdrf:contribute {PXD} to create a PR, or see the commands to do it manually.
 ```
 
-3. If the PXD already exists in annotated-projects/, mention this is an update to an existing annotation
+3. If the PXD already existed, this is an **update**. The PR description must
+   state what was wrong with the previous annotation and cite the evidence
+   (deposited run list, PRIDE-registered organisms, the audit findings), so a
+   reviewer can verify the claim instead of trusting it.
 
 This step is a recommendation only — do not force the user to contribute.
 
 ## Important Rules
 
+- NEVER re-annotate an already-annotated dataset silently — audit it, report, and
+  let the user choose (Step 0.5). Overwriting requires an explicit `reannotate`
 - NEVER fabricate ontology accessions — always search OLS
 - NEVER guess file names — get them from PRIDE file list
 - NEVER invent sample information not found in the paper or PRIDE metadata

--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -26,28 +26,59 @@ it without anyone noticing the first was broken.
 
 ### 0.5.1 Look it up in the community repository
 
+**Enumerate the accession directory — do not probe for a single filename.** A PXD
+directory may hold several SDRFs distinguished by descriptive suffixes
+(`PXD004452-tissues.sdrf.tsv` + `PXD004452-celllines.sdrf.tsv`,
+`PXD006430-tmt.sdrf.tsv` + `PXD006430-silac.sdrf.tsv`), and many accessions have
+**no** `{PXD}.sdrf.tsv` at all — only a suffixed variant such as
+`PXD001064-DIA.sdrf.tsv`. Checking one canonical name reports those as `new` and
+skips the gate entirely.
+
 ```bash
-gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD}/{PXD}.sdrf.tsv \
-  --jq .download_url 2>/dev/null || echo "new"
+gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD} \
+  --jq '.[] | select(.name | endswith(".sdrf.tsv")) | .name' 2>/dev/null
 ```
 
 Check the **community repository**, which is authoritative. A local
 `spec/annotated-projects/` copy may be stale, so do not rely on it alone.
 
-**If it does not exist** → this is a new annotation. Continue to Step 1 normally.
+Interpret the listing as an **artifact set**, not a yes/no:
 
-**If it exists → STOP. Do not annotate yet.** Go to 0.5.2.
+- **No directory, or no `.sdrf.tsv` in it** → new annotation. Continue to Step 1.
+- **The file you intend to write already exists** → STOP, go to 0.5.2.
+- **Only other SDRFs exist for this PXD** (a different sub-experiment, e.g. you
+  are writing `-celllines` and only `-tissues` is present) → this is still a new
+  file, but say so explicitly and name the sibling files, since they constrain
+  what your file should cover and how it should be named. Audit a sibling only if
+  you intend to replace it.
+
+Use the same artifact set in `/sdrf:contribute` rather than recomputing it, so the
+two workflows cannot disagree about what "already annotated" means.
 
 ### 0.5.2 Audit the existing annotation
 
 Never assume the existing file is right, and never assume it is wrong. Fetch it
 and audit it against the deposit:
 
+**The audit must not run on a failed download.** `curl -o` truncates its target
+even when the request fails, so an unchecked fetch can leave an empty file or an
+HTML error page and the audit will then describe *that* instead of the
+annotation. Chain on success, and use `curl -f` so an HTTP error is a failure:
+
 ```bash
-curl -sL "$(gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD}/{PXD}.sdrf.tsv --jq .download_url)" -o existing.sdrf.tsv
+set -euo pipefail
+url=$(gh api "repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD}/{FILE}" --jq .download_url)
+[ -n "$url" ] || { echo "could not resolve download URL — abort, do NOT audit"; exit 1; }
+curl -fsSL "$url" -o existing.sdrf.tsv
+[ -s existing.sdrf.tsv ] || { echo "empty download — abort, do NOT audit"; exit 1; }
+
 python -m tools audit-existing existing.sdrf.tsv --accession {PXD} \
   --runs deposited_runs.txt --organism "<each organism PRIDE registers>"
 ```
+
+If any step fails, report the failure and stop. Never treat a fetch error as
+"no existing annotation" — that turns an infrastructure problem into a silent
+overwrite.
 
 The audit is mechanical and checks only what the deposit can settle:
 
@@ -60,12 +91,29 @@ The audit is mechanical and checks only what the deposit can settle:
 | `no_factor_value` | major | no factor value column declared |
 | `characteristics_not_bare_label`, `source_name_convention` | minor | convention drift |
 
-Also run `parse_sdrf validate-sdrf` on the existing file — a file can be valid and
-still be wrong about the deposit, so the two checks are complementary.
+Also validate the existing file — it can be structurally valid and still be wrong
+about the deposit, so the two checks are complementary. Validate the way the rest
+of this repo requires: **once per declared template, against the rows that declare
+it, requiring every run to pass.** `--template` is single-valued, so passing
+several flags silently validates against only the last one:
+
+```bash
+# read the declared templates from the file itself
+cut -f"$(head -1 existing.sdrf.tsv | tr '\t' '\n' | grep -n '^comment\[sdrf template\]$' | cut -d: -f1)" \
+  existing.sdrf.tsv | tail -n +2 | sort -u
+
+# then, once per declared template
+parse_sdrf validate-sdrf --sdrf_file existing.sdrf.tsv --template <one-template>
+```
+
+Use `spec/scripts/resolve_templates.py` for the authoritative multi-template
+constraint set (column licensing and reserved-word `allow_*`); `parse_sdrf`
+enforces neither.
 
 `--runs` and `--organism` are optional, and when omitted the corresponding checks
 are **skipped, not passed**. Supply them whenever you have them, and say which
-checks were skipped when reporting.
+checks were skipped when reporting. If you supply them and the SDRF lacks the
+column they check, the audit reports that as a blocker rather than a skip.
 
 ### 0.5.3 Report and let the USER decide
 

--- a/skills/sdrf-contribute/SKILL.md
+++ b/skills/sdrf-contribute/SKILL.md
@@ -36,8 +36,31 @@ gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD} \
 ```
 
 - **New annotation**: The PXD folder does not exist → this is a new contribution
-- **Update**: The PXD folder already exists → this updates an existing annotation
-- Report which case it is to the user
+- **Update**: The PXD folder already exists → this **replaces a file someone else
+  curated**, so it needs justification, not just a report
+
+For the update case, do not open the PR yet. Audit the file you are about to
+replace, so the PR can say what was actually wrong with it:
+
+```bash
+curl -sL "$(gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD}/{PXD}.sdrf.tsv --jq .download_url)" -o existing.sdrf.tsv
+python -m tools audit-existing existing.sdrf.tsv --accession {PXD} \
+  --runs deposited_runs.txt --organism "<each organism PRIDE registers>"
+```
+
+Then:
+
+- **The audit is clean and your version is merely different** → say so and ask the
+  user whether to proceed. Replacing a correct annotation with an equivalent one
+  costs reviewer time and can regress hand curation. Style-only changes are rarely
+  worth a PR on their own.
+- **The audit found defects** → proceed, and make the PR body lead with them:
+  each defect, the evidence from the deposit, and what the new file does instead.
+  A reviewer must be able to check the claim rather than trust it.
+
+If `/sdrf:annotate` already ran its Step 0.5 gate for this accession, reuse that
+audit instead of repeating it, and confirm the user chose `fix` or `reannotate`.
+**Never open a PR that silently overwrites an existing annotation.**
 
 ## Step 2: Validate Before Contributing
 

--- a/skills/sdrf-contribute/SKILL.md
+++ b/skills/sdrf-contribute/SKILL.md
@@ -35,15 +35,33 @@ gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD} \
   --silent && echo "exists" || echo "new"
 ```
 
-- **New annotation**: The PXD folder does not exist → this is a new contribution
-- **Update**: The PXD folder already exists → this **replaces a file someone else
-  curated**, so it needs justification, not just a report
-
-For the update case, do not open the PR yet. Audit the file you are about to
-replace, so the PR can say what was actually wrong with it:
+Classify at the level of the **file you are about to write**, not the directory.
+A PXD folder may legitimately hold several SDRFs with descriptive suffixes
+(`PXD006430-tmt.sdrf.tsv` + `PXD006430-silac.sdrf.tsv`), so an existing folder
+does not mean you are replacing anything:
 
 ```bash
-curl -sL "$(gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD}/{PXD}.sdrf.tsv --jq .download_url)" -o existing.sdrf.tsv
+gh api repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD} \
+  --jq '.[] | select(.name | endswith(".sdrf.tsv")) | .name' 2>/dev/null
+```
+
+- **New annotation**: your target filename is not in that listing → new
+  contribution, even if the folder already exists. Name any sibling files in the
+  PR so a reviewer can see how the sub-experiments divide.
+- **Update**: your target filename IS in the listing → this **replaces a file
+  someone else curated**, so it needs justification, not just a report.
+
+For the update case, do not open the PR yet. Audit the file you are about to
+replace, so the PR can say what was actually wrong with it. Abort on a failed
+fetch rather than auditing a truncated or error-page file:
+
+```bash
+set -euo pipefail
+url=$(gh api "repos/bigbio/sdrf-annotated-datasets/contents/datasets/{PXD}/{FILE}" --jq .download_url)
+[ -n "$url" ] || { echo "could not resolve download URL — abort"; exit 1; }
+curl -fsSL "$url" -o existing.sdrf.tsv
+[ -s existing.sdrf.tsv ] || { echo "empty download — abort"; exit 1; }
+
 python -m tools audit-existing existing.sdrf.tsv --accession {PXD} \
   --runs deposited_runs.txt --organism "<each organism PRIDE registers>"
 ```

--- a/tests/test_existing_annotation.py
+++ b/tests/test_existing_annotation.py
@@ -172,3 +172,81 @@ class TestProvenanceColumnsAreNotOntologyTerms:
                      "1", "1", "r1.raw", "c")]
         report = audit(_sdrf(rows), accession="PXD1")
         assert any(f.code == "cv_term_no_accession" for f in report.findings)
+
+
+class TestReviewFindings:
+    """Regression tests for the review feedback on PR #46."""
+
+    def test_utf8_bom_does_not_silently_disable_checks(self):
+        """A BOM turned 'source name' into '﻿source name', so every column
+        lookup missed and the audit reported a clean file."""
+        report = audit("﻿" + GOOD, deposited_runs=["r1.raw", "r9.raw"],
+                       accession="PXD1")
+        assert any(f.code == "missing_runs" for f in report.findings), report.render()
+
+    def test_blank_data_file_is_not_reported_as_an_invented_run(self):
+        rows = [
+            _row("PXD1-Sample-1", "Homo sapiens", "normal", "r1", "NT=x;AC=MS:1",
+                 "NT=y;AC=MS:2", "1", "1", "r1.raw", "c"),
+            _row("PXD1-Sample-2", "Homo sapiens", "normal", "r2", "NT=x;AC=MS:1",
+                 "NT=y;AC=MS:2", "1", "1", "", "c"),
+        ]
+        report = audit(_sdrf(rows), deposited_runs=["r1.raw"], accession="PXD1")
+        assert any(f.code == "blank_data_file" for f in report.findings)
+        assert not any(f.code == "invented_runs" for f in report.findings)
+
+    def test_surrounding_whitespace_does_not_double_report(self):
+        rows = [_row("PXD1-Sample-1", "Homo sapiens", "normal", "r1", "NT=x;AC=MS:1",
+                     "NT=y;AC=MS:2", "1", "1", "  r1.raw  ", "c")]
+        report = audit(_sdrf(rows), deposited_runs=["r1.raw"], accession="PXD1")
+        assert not any(f.code in ("missing_runs", "invented_runs") for f in report.findings)
+
+    def test_evidence_supplied_but_data_file_column_absent_is_reported(self):
+        header = HEADER.replace("\tcomment[data file]", "")
+        cells = ("PXD1-Sample-1", "Homo sapiens", "normal", "r1",
+                 "NT=x;AC=MS:1", "NT=y;AC=MS:2", "1", "1", "c")
+        rows = ["\t".join(cells)]
+        report = audit(_sdrf(rows, header=header), deposited_runs=["r1.raw"],
+                       accession="PXD1")
+        f = next(f for f in report.findings if f.code == "no_data_file_column")
+        assert f.severity == BLOCKER
+        assert report.recommendation == "reannotate"
+
+    def test_evidence_supplied_but_organism_column_absent_is_reported(self):
+        header = HEADER.replace("characteristics[organism]\t", "")
+        cells = ("PXD1-Sample-1", "normal", "r1", "NT=x;AC=MS:1",
+                 "NT=y;AC=MS:2", "1", "1", "r1.raw", "c")
+        rows = ["\t".join(cells)]
+        report = audit(_sdrf(rows, header=header), pride_organisms=["Homo sapiens"],
+                       accession="PXD1")
+        assert any(f.code == "no_organism_column" and f.severity == BLOCKER
+                   for f in report.findings)
+
+    def test_vv_on_a_real_cv_column_is_not_exempt(self):
+        """Only the named provenance columns are exempt — a VV= anywhere else
+        must not excuse a missing accession."""
+        rows = [_row("PXD1-Sample-1", "Homo sapiens", "normal", "r1",
+                     "NT=Some Instrument;VV=v1", "NT=y;AC=MS:2", "1", "1",
+                     "r1.raw", "c")]
+        report = audit(_sdrf(rows), accession="PXD1")
+        assert any(f.code == "cv_term_no_accession" for f in report.findings)
+
+    def test_empty_accession_value_is_not_an_accession(self):
+        rows = [_row("PXD1-Sample-1", "Homo sapiens", "normal", "r1",
+                     "NT=Some Instrument;AC=", "NT=y;AC=MS:2", "1", "1", "r1.raw", "c")]
+        report = audit(_sdrf(rows), accession="PXD1")
+        assert any(f.code == "cv_term_no_accession" for f in report.findings)
+
+    def test_source_name_suffix_must_be_numeric(self):
+        for bad in ("PXD1-Sample-abc", "PXD1-Sample-"):
+            rows = [_row(bad, "Homo sapiens", "normal", "r1", "NT=x;AC=MS:1",
+                         "NT=y;AC=MS:2", "1", "1", "r1.raw", "c")]
+            report = audit(_sdrf(rows), accession="PXD1")
+            assert any(f.code == "source_name_convention" for f in report.findings), bad
+
+    def test_accession_is_regex_escaped(self):
+        """A '.' in the accession must not act as a wildcard."""
+        rows = [_row("PXDx1-Sample-1", "Homo sapiens", "normal", "r1", "NT=x;AC=MS:1",
+                     "NT=y;AC=MS:2", "1", "1", "r1.raw", "c")]
+        report = audit(_sdrf(rows), accession="PXD.1")
+        assert any(f.code == "source_name_convention" for f in report.findings)

--- a/tests/test_existing_annotation.py
+++ b/tests/test_existing_annotation.py
@@ -1,0 +1,174 @@
+"""Tests for tools.existing_annotation — auditing an already-annotated dataset."""
+
+from __future__ import annotations
+
+from tools.existing_annotation import BLOCKER, MAJOR, MINOR, audit
+
+HEADER = (
+    "source name\tcharacteristics[organism]\tcharacteristics[disease]\t"
+    "assay name\tcomment[instrument]\tcomment[dissociation method]\t"
+    "comment[fraction identifier]\tcomment[technical replicate]\t"
+    "comment[data file]\tfactor value[phenotype]"
+)
+
+
+def _sdrf(rows: list[str], header: str = HEADER) -> str:
+    return header + "\n" + "\n".join(rows) + "\n"
+
+
+def _row(src, org, disease, assay, instr, diss, frac, tech, dfile, factor):
+    fields = (src, org, disease, assay, instr, diss, frac, tech, dfile, factor)
+    return "\t".join(fields)
+
+
+GOOD = _sdrf([
+    _row("PXD1-Sample-1", "Homo sapiens", "normal", "r1",
+         "NT=Orbitrap Fusion Lumos;AC=MS:1002732",
+         "NT=beam-type collision-induced dissociation;AC=MS:1000422",
+         "1", "1", "r1.raw", "control"),
+    _row("PXD1-Sample-1", "Homo sapiens", "normal", "r2",
+         "NT=Orbitrap Fusion Lumos;AC=MS:1002732",
+         "NT=beam-type collision-induced dissociation;AC=MS:1000422",
+         "1", "2", "r2.raw", "control"),
+    _row("PXD1-Sample-2", "Homo sapiens", "normal", "r3",
+         "NT=Orbitrap Fusion Lumos;AC=MS:1002732",
+         "NT=beam-type collision-induced dissociation;AC=MS:1000422",
+         "1", "1", "r3.raw", "treated"),
+])
+
+
+class TestCleanAnnotation:
+    def test_no_findings_when_consistent(self):
+        report = audit(GOOD, deposited_runs=["r1.raw", "r2.raw", "r3.raw"],
+                       pride_organisms=["Homo sapiens (human)"], accession="PXD1")
+        assert report.clean, report.render()
+        assert report.recommendation == "leave"
+        assert report.n_rows == 3
+
+    def test_checks_are_skipped_not_guessed_when_context_missing(self):
+        """No deposit info supplied -> no coverage/organism findings invented."""
+        report = audit(GOOD, accession="PXD1")
+        codes = {f.code for f in report.findings}
+        assert "missing_runs" not in codes
+        assert "organism_mismatch" not in codes
+
+
+class TestCoverage:
+    def test_detects_missing_runs(self):
+        report = audit(GOOD, deposited_runs=["r1.raw", "r2.raw", "r3.raw", "r4.raw"],
+                       accession="PXD1")
+        f = next(f for f in report.findings if f.code == "missing_runs")
+        assert f.severity == BLOCKER
+        assert "r4.raw" in f.evidence
+        assert report.recommendation == "reannotate"
+
+    def test_detects_invented_runs(self):
+        report = audit(GOOD, deposited_runs=["r1.raw", "r2.raw"], accession="PXD1")
+        assert any(f.code == "invented_runs" and f.severity == BLOCKER
+                   for f in report.findings)
+
+
+class TestOrganism:
+    def test_detects_unrepresented_organism(self):
+        """The PXD017812 case: a 3-species mixture annotated as one species."""
+        report = audit(
+            GOOD,
+            deposited_runs=["r1.raw", "r2.raw", "r3.raw"],
+            pride_organisms=["Homo sapiens (human)", "Saccharomyces cerevisiae",
+                             "Escherichia coli"],
+            accession="PXD1",
+        )
+        f = next(f for f in report.findings if f.code == "organism_mismatch")
+        assert f.severity == BLOCKER
+        assert "saccharomyces cerevisiae" in f.evidence
+        assert "escherichia coli" in f.evidence
+
+    def test_parenthetical_common_name_does_not_trip_it(self):
+        report = audit(GOOD, pride_organisms=["Homo sapiens (human)"], accession="PXD1")
+        assert not any(f.code == "organism_mismatch" for f in report.findings)
+
+
+class TestCounterAbuse:
+    def test_detects_technical_replicate_used_as_row_index(self):
+        rows = [
+            _row(f"S{i}", "Homo sapiens", "normal", f"r{i}", "NT=x;AC=MS:1", "NT=y;AC=MS:2",
+                 "1", str(i), f"r{i}.raw", "c")
+            for i in range(1, 6)
+        ]
+        report = audit(_sdrf(rows))
+        f = next(f for f in report.findings if f.code == "counter_abuse")
+        assert f.severity == MAJOR
+        assert "comment[technical replicate]" in f.summary
+
+    def test_legitimate_replicate_numbering_is_not_flagged(self):
+        assert not any(f.code == "counter_abuse" for f in audit(GOOD).findings)
+
+
+class TestMalformedTerms:
+    def test_detects_nt_without_accession(self):
+        rows = [_row("PXD1-Sample-1", "Homo sapiens", "normal", "r1",
+                     "NT=Orbitrap Fusion Lumos;AC=MS:1002732", "NT=HCD",
+                     "1", "1", "r1.raw", "c")]
+        report = audit(_sdrf(rows))
+        f = next(f for f in report.findings if f.code == "cv_term_no_accession")
+        assert f.severity == MAJOR
+
+
+class TestStructure:
+    def test_detects_missing_factor_value(self):
+        header = HEADER.replace("\tfactor value[phenotype]", "")
+        rows = [_row("PXD1-Sample-1", "Homo sapiens", "normal", "r1", "NT=x;AC=MS:1",
+                     "NT=y;AC=MS:2", "1", "1", "r1.raw", "c").rsplit("\t", 1)[0]]
+        report = audit(_sdrf(rows, header=header))
+        assert any(f.code == "no_factor_value" for f in report.findings)
+
+    def test_empty_file_is_a_blocker(self):
+        report = audit("")
+        assert report.findings[0].severity == BLOCKER
+
+
+class TestConventions:
+    def test_detects_ntac_in_characteristics(self):
+        rows = [_row("PXD1-Sample-1", "NT=Homo sapiens;AC=NCBITaxon:9606", "normal", "r1",
+                     "NT=x;AC=MS:1", "NT=y;AC=MS:2", "1", "1", "r1.raw", "c")]
+        report = audit(_sdrf(rows))
+        f = next(f for f in report.findings if f.code == "characteristics_not_bare_label")
+        assert f.severity == MINOR
+
+    def test_detects_source_name_convention_drift(self):
+        rows = [_row("Saccharomyces_cerevisiae_1", "Homo sapiens", "normal", "r1",
+                     "NT=x;AC=MS:1", "NT=y;AC=MS:2", "1", "1", "r1.raw", "c")]
+        report = audit(_sdrf(rows), accession="PXD1")
+        assert any(f.code == "source_name_convention" for f in report.findings)
+
+    def test_convention_drift_alone_recommends_fix_not_reannotate(self):
+        rows = [_row("Saccharomyces_cerevisiae_1", "NT=Homo sapiens;AC=NCBITaxon:9606",
+                     "normal", "r1", "NT=x;AC=MS:1", "NT=y;AC=MS:2", "1", "1",
+                     "r1.raw", "c")]
+        report = audit(_sdrf(rows), accession="PXD1")
+        assert not report.blockers
+        assert report.recommendation == "fix"
+
+
+class TestProvenanceColumnsAreNotOntologyTerms:
+    """Regression: comment[sdrf template]/[sdrf annotation tool] use NT=..;VV=..
+    and legitimately carry no AC= accession. An earlier version of the audit
+    flagged every correctly-annotated file because of this."""
+
+    def test_template_and_tool_columns_are_exempt(self):
+        header = HEADER + "\tcomment[sdrf template]\tcomment[sdrf annotation tool]"
+        rows = [_row("PXD1-Sample-1", "Homo sapiens", "normal", "r1",
+                     "NT=Orbitrap Fusion Lumos;AC=MS:1002732",
+                     "NT=beam-type collision-induced dissociation;AC=MS:1000422",
+                     "1", "1", "r1.raw", "c")
+                + "\tNT=ms-proteomics;VV=v1.1.0\tNT=sdrf-skills;VV=v0.2.0"]
+        report = audit(_sdrf(rows, header=header), accession="PXD1")
+        assert not any(f.code == "cv_term_no_accession" for f in report.findings), \
+            report.render()
+
+    def test_a_real_missing_accession_is_still_caught(self):
+        rows = [_row("PXD1-Sample-1", "Homo sapiens", "normal", "r1",
+                     "NT=Orbitrap Fusion Lumos;AC=MS:1002732", "NT=HCD",
+                     "1", "1", "r1.raw", "c")]
+        report = audit(_sdrf(rows), accession="PXD1")
+        assert any(f.code == "cv_term_no_accession" for f in report.findings)

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -169,11 +169,12 @@ def cmd_audit_existing(args: argparse.Namespace) -> int:
 
     runs = None
     if args.runs:
-        runs = [ln.strip() for ln in Path(args.runs).read_text().splitlines() if ln.strip()]
+        runs_text = Path(args.runs).read_text(encoding="utf-8-sig")
+        runs = [ln.strip() for ln in runs_text.splitlines() if ln.strip()]
     organisms = args.organism or None
 
     report = audit(
-        Path(args.sdrf_file).read_text(encoding="utf-8"),
+        Path(args.sdrf_file).read_text(encoding="utf-8-sig"),
         deposited_runs=runs,
         pride_organisms=organisms,
         accession=args.accession or "",

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -9,6 +9,7 @@ Usage:
   python -m tools cellline lookup <name>           # curated cell line lookup
   python -m tools massive-files <PXD|MSV|task>     # MassIVE raw/acquisition file resolver
   python -m tools review-gate <command>             # independent-review receipt gate
+  python -m tools audit-existing <file.sdrf.tsv>    # audit an already-annotated dataset
 """
 
 from __future__ import annotations
@@ -160,6 +161,33 @@ def cmd_review_gate(args: argparse.Namespace) -> int:
     return run_cli(args.review_gate_args)
 
 
+def cmd_audit_existing(args: argparse.Namespace) -> int:
+    """Audit an SDRF that already exists for a dataset, before re-annotating it."""
+    from pathlib import Path
+
+    from tools.existing_annotation import audit
+
+    runs = None
+    if args.runs:
+        runs = [ln.strip() for ln in Path(args.runs).read_text().splitlines() if ln.strip()]
+    organisms = args.organism or None
+
+    report = audit(
+        Path(args.sdrf_file).read_text(encoding="utf-8"),
+        deposited_runs=runs,
+        pride_organisms=organisms,
+        accession=args.accession or "",
+    )
+    print(report.render())
+    print(f"\nsuggested action: {report.recommendation}")
+    if not args.runs or not organisms:
+        skipped = [n for n, v in (("--runs", args.runs), ("--organism", organisms)) if not v]
+        print(f"note: {', '.join(skipped)} not supplied, so those checks were SKIPPED (not passed)")
+    # Exit non-zero only for blockers, so this can gate a workflow without
+    # blocking on convention drift.
+    return 1 if report.blockers else 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="python -m tools",
@@ -232,6 +260,18 @@ def main() -> None:
     )
     p.add_argument("review_gate_args", nargs=argparse.REMAINDER)
 
+    # audit-existing
+    p = subparsers.add_parser(
+        "audit-existing",
+        help="Audit an SDRF that already exists for a dataset, before re-annotating",
+    )
+    p.add_argument("sdrf_file", help="the EXISTING SDRF (e.g. from the community repo)")
+    p.add_argument("--accession", default=None, help="PXD accession, enables convention checks")
+    p.add_argument("--runs", default=None,
+                   help="file with one deposited run filename per line; omitted = coverage check skipped")
+    p.add_argument("--organism", action="append", default=None,
+                   help="organism registered in PRIDE (repeatable); omitted = organism check skipped")
+
     args = parser.parse_args()
 
     # Set default db path for cellline commands
@@ -248,6 +288,7 @@ def main() -> None:
         "cellline": cmd_cellline,
         "verify": cmd_verify,
         "review-gate": cmd_review_gate,
+        "audit-existing": cmd_audit_existing,
     }
 
     sys.exit(commands[args.command](args))

--- a/tools/existing_annotation.py
+++ b/tools/existing_annotation.py
@@ -84,6 +84,11 @@ class AuditReport:
 
 
 def _read(sdrf_text: str) -> tuple[list[str], list[list[str]]]:
+    # An SDRF saved from Excel commonly carries a UTF-8 BOM. Left in place it
+    # turns the first header cell into "﻿source name", every column lookup
+    # misses, and the audit reports a clean file — the worst possible failure
+    # mode for a gate.
+    sdrf_text = sdrf_text.lstrip("﻿")
     rows = list(csv.reader(io.StringIO(sdrf_text), delimiter="\t"))
     if not rows:
         return [], []
@@ -118,9 +123,24 @@ def audit(
 
     # ---- run coverage -----------------------------------------------------
     file_ix = _cols(header, "comment[data file]")
+    if deposited_runs is not None and not file_ix:
+        # Evidence WAS supplied, so this is not a skipped check - the SDRF
+        # cannot support it. Staying silent here would return "leave" for a
+        # file that has no run mapping at all.
+        report.findings.append(Finding(
+            "no_data_file_column", BLOCKER,
+            "the SDRF has no comment[data file] column, so no row can be tied "
+            "to a deposited run"))
     if deposited_runs is not None and file_ix:
-        deposited = {r for r in deposited_runs}
-        annotated = _values(rows, file_ix)
+        deposited = {r.strip() for r in deposited_runs if r.strip()}
+        raw = _values(rows, file_ix)
+        annotated = {v.strip() for v in raw if v.strip()}
+        # A blank cell is a real defect, but calling it an "invented run" is
+        # confusing, so it is reported on its own.
+        if any(not v.strip() for v in raw):
+            report.findings.append(Finding(
+                "blank_data_file", MAJOR,
+                "comment[data file] has blank cell(s), so some rows name no run"))
         missing = deposited - annotated
         invented = annotated - deposited
         if missing:
@@ -136,6 +156,11 @@ def audit(
 
     # ---- organism agreement ----------------------------------------------
     org_ix = _cols(header, "characteristics[organism]")
+    if pride_organisms and not org_ix:
+        report.findings.append(Finding(
+            "no_organism_column", BLOCKER,
+            "the SDRF has no characteristics[organism] column, so the organisms "
+            "PRIDE registers cannot be checked"))
     if pride_organisms and org_ix:
         def norm(s: str) -> str:
             s = re.sub(r"NT=([^;]*).*", r"\1", s)
@@ -167,8 +192,11 @@ def audit(
 
     # ---- malformed CV terms ----------------------------------------------
     # Provenance columns legitimately use NT=<name>;VV=<version> and carry no
-    # ontology accession, so an absent AC= is only a defect elsewhere.
+    # ontology accession. They are excluded BY NAME: exempting every value that
+    # merely contains "VV=" would also excuse a real CV column written that way,
+    # and an empty "AC=" is not an accession either.
     provenance = {"comment[sdrf template]", "comment[sdrf annotation tool]"}
+    has_accession = re.compile(r"AC=\s*\S")
     malformed = set()
     for i, col in enumerate(header):
         if not col.startswith("comment[") or col in provenance:
@@ -177,7 +205,7 @@ def audit(
             if i >= len(r):
                 continue
             v = r[i]
-            if v.startswith("NT=") and "AC=" not in v and "VV=" not in v:
+            if v.startswith("NT=") and not has_accession.search(v):
                 malformed.add(f"{col}={v}")
     if malformed:
         report.findings.append(Finding(
@@ -206,7 +234,8 @@ def audit(
         src_ix = _cols(header, "source name")
         if src_ix:
             srcs = _values(rows, src_ix)
-            if srcs and not all(s.startswith(f"{accession}-Sample-") for s in srcs):
+            expected = re.compile(rf"{re.escape(accession)}-Sample-\d+")
+            if srcs and not all(expected.fullmatch(s.strip()) for s in srcs):
                 report.findings.append(Finding(
                     "source_name_convention", MINOR,
                     "source name does not follow <ACCESSION>-Sample-<n>",

--- a/tools/existing_annotation.py
+++ b/tools/existing_annotation.py
@@ -1,0 +1,215 @@
+"""Detect and audit an SDRF annotation that already exists for a dataset.
+
+Annotating a dataset that is already annotated is not a no-op: the existing file
+may be complete and correct (in which case re-annotating wastes effort and
+produces a noisy diff), or it may be silently wrong (in which case shipping a
+"new" annotation alongside it hides the defect). This module answers both
+questions mechanically so the skill can stop and ask the user with evidence
+rather than guessing.
+
+The audit deliberately only reports defects that can be established from the
+deposit itself — run coverage, organism agreement, structural misuse of the
+replicate/fraction columns, malformed CV terms. It never judges biological
+interpretation, which needs a human.
+
+Typical use, once the skill has established that an annotation exists and has
+fetched its text:
+
+    report = audit(existing_sdrf_text, deposited_runs, pride_organisms, accession)
+    print(report.render())
+    # report.recommendation is a SUGGESTION - the user still chooses.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+
+# Severity drives the recommendation, not the wording of the message.
+BLOCKER = "blocker"   # the annotation misrepresents the deposit
+MAJOR = "major"       # real defect, but the file still describes the right data
+MINOR = "minor"       # convention drift
+
+
+@dataclass
+class Finding:
+    code: str
+    severity: str
+    summary: str
+    evidence: str = ""
+
+    def __str__(self) -> str:
+        tail = f"  [{self.evidence}]" if self.evidence else ""
+        return f"{self.severity.upper():8s} {self.code}: {self.summary}{tail}"
+
+
+@dataclass
+class AuditReport:
+    accession: str
+    n_rows: int = 0
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def blockers(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == BLOCKER]
+
+    @property
+    def clean(self) -> bool:
+        return not self.findings
+
+    @property
+    def recommendation(self) -> str:
+        """What to suggest to the user. The user still decides."""
+        if self.clean:
+            return "leave"
+        if self.blockers:
+            return "reannotate"
+        return "fix"
+
+    def render(self) -> str:
+        if self.clean:
+            return (
+                f"{self.accession} is already annotated ({self.n_rows} rows) and the "
+                f"automated audit found no defects."
+            )
+        headline = (f"{self.accession} is already annotated ({self.n_rows} rows), "
+                    f"but the audit found {len(self.findings)} issue(s):")
+        lines = [headline, ""]
+        order = {BLOCKER: 0, MAJOR: 1, MINOR: 2}
+        lines += [f"  {f}" for f in sorted(self.findings, key=lambda f: order[f.severity])]
+        return "\n".join(lines)
+
+
+def _read(sdrf_text: str) -> tuple[list[str], list[list[str]]]:
+    rows = list(csv.reader(io.StringIO(sdrf_text), delimiter="\t"))
+    if not rows:
+        return [], []
+    return rows[0], [r for r in rows[1:] if r]
+
+
+def _cols(header: Sequence[str], name: str) -> list[int]:
+    """All indices for a column name — SDRF legitimately repeats some columns."""
+    return [i for i, c in enumerate(header) if c.strip() == name]
+
+
+def _values(rows: Iterable[Sequence[str]], idx: Sequence[int]) -> set[str]:
+    return {r[i] for r in rows for i in idx if i < len(r)}
+
+
+def audit(
+    sdrf_text: str,
+    deposited_runs: Iterable[str] | None = None,
+    pride_organisms: Iterable[str] | None = None,
+    accession: str = "",
+) -> AuditReport:
+    """Audit an existing SDRF against what the deposit actually contains.
+
+    `deposited_runs` and `pride_organisms` are optional: when they are not
+    supplied the corresponding checks are skipped rather than guessed at.
+    """
+    header, rows = _read(sdrf_text)
+    report = AuditReport(accession=accession, n_rows=len(rows))
+    if not header:
+        report.findings.append(Finding("empty", BLOCKER, "the existing SDRF is empty"))
+        return report
+
+    # ---- run coverage -----------------------------------------------------
+    file_ix = _cols(header, "comment[data file]")
+    if deposited_runs is not None and file_ix:
+        deposited = {r for r in deposited_runs}
+        annotated = _values(rows, file_ix)
+        missing = deposited - annotated
+        invented = annotated - deposited
+        if missing:
+            report.findings.append(Finding(
+                "missing_runs", BLOCKER,
+                f"{len(missing)} deposited run(s) are not annotated",
+                ", ".join(sorted(missing)[:3]) + ("..." if len(missing) > 3 else "")))
+        if invented:
+            report.findings.append(Finding(
+                "invented_runs", BLOCKER,
+                f"{len(invented)} annotated run(s) do not exist in the deposit",
+                ", ".join(sorted(invented)[:3]) + ("..." if len(invented) > 3 else "")))
+
+    # ---- organism agreement ----------------------------------------------
+    org_ix = _cols(header, "characteristics[organism]")
+    if pride_organisms and org_ix:
+        def norm(s: str) -> str:
+            s = re.sub(r"NT=([^;]*).*", r"\1", s)
+            s = re.sub(r"\(.*?\)", "", s)
+            return re.sub(r"\s+", " ", s).strip().lower()
+
+        declared = {norm(o) for o in pride_organisms} - {""}
+        used = {norm(v) for v in _values(rows, org_ix)} - {"", "not available", "not applicable"}
+        unrepresented = {d for d in declared if not any(d in u or u in d for u in used)}
+        if unrepresented:
+            report.findings.append(Finding(
+                "organism_mismatch", BLOCKER,
+                (f"PRIDE registers {len(declared)} organism(s) but "
+                 f"{len(unrepresented)} never appear in the SDRF"),
+                "missing: " + ", ".join(sorted(unrepresented))))
+
+    # ---- replicate / fraction columns used as row counters ----------------
+    for col in ("comment[technical replicate]", "comment[fraction identifier]",
+                "characteristics[biological replicate]"):
+        ix = _cols(header, col)
+        if not ix or len(rows) < 3:
+            continue
+        vals = [r[ix[0]] for r in rows if ix[0] < len(r)]
+        if len(set(vals)) == len(vals) and set(vals) == {str(i) for i in range(1, len(vals) + 1)}:
+            report.findings.append(Finding(
+                "counter_abuse", MAJOR,
+                f"{col} runs 1..{len(vals)} with every row distinct — it is being used "
+                f"as a row index, not a replicate/fraction number"))
+
+    # ---- malformed CV terms ----------------------------------------------
+    # Provenance columns legitimately use NT=<name>;VV=<version> and carry no
+    # ontology accession, so an absent AC= is only a defect elsewhere.
+    provenance = {"comment[sdrf template]", "comment[sdrf annotation tool]"}
+    malformed = set()
+    for i, col in enumerate(header):
+        if not col.startswith("comment[") or col in provenance:
+            continue
+        for r in rows:
+            if i >= len(r):
+                continue
+            v = r[i]
+            if v.startswith("NT=") and "AC=" not in v and "VV=" not in v:
+                malformed.add(f"{col}={v}")
+    if malformed:
+        report.findings.append(Finding(
+            "cv_term_no_accession", MAJOR,
+            f"{len(malformed)} CV term(s) carry NT= with no AC= accession",
+            "; ".join(sorted(malformed)[:2])))
+
+    # ---- factor value ------------------------------------------------------
+    if not any(c.startswith("factor value[") for c in header):
+        report.findings.append(Finding(
+            "no_factor_value", MAJOR,
+            "the SDRF declares no factor value column"))
+
+    # ---- convention drift --------------------------------------------------
+    char_ntac = sorted({
+        c for i, c in enumerate(header) if c.startswith("characteristics[")
+        for r in rows if i < len(r) and ("NT=" in r[i] or "AC=" in r[i])
+    })
+    if char_ntac:
+        report.findings.append(Finding(
+            "characteristics_not_bare_label", MINOR,
+            f"{len(char_ntac)} characteristics column(s) use NT=..;AC=.. instead of a bare label",
+            ", ".join(char_ntac[:3])))
+
+    if accession:
+        src_ix = _cols(header, "source name")
+        if src_ix:
+            srcs = _values(rows, src_ix)
+            if srcs and not all(s.startswith(f"{accession}-Sample-") for s in srcs):
+                report.findings.append(Finding(
+                    "source_name_convention", MINOR,
+                    "source name does not follow <ACCESSION>-Sample-<n>",
+                    min(srcs)))
+
+    return report


### PR DESCRIPTION
## What happens when a dataset is already annotated?

Right now: nothing useful. `/sdrf:annotate` builds the entire annotation and only then, at **Step 11 of 11**, checks whether the PXD already exists — and it checks `spec/annotated-projects/`, a local copy that can be stale. `/sdrf:contribute` Step 1.3 does check the community repository, but only to *report* "new vs update" before proceeding either way.

Two bad outcomes follow:

1. You do the full annotation before discovering it was already done.
2. You can silently replace someone else's curated file, with a PR that doesn't say why.

### The design here: gate, then audit, then let the user choose

You listed refuse-and-warn vs detect-errors-and-fix. This implements the **combination**, with one addition that I think matters more than either half: the decision is only useful if it's *informed*, so the gate runs a mechanical audit and hands the user evidence rather than a yes/no.

**Step 0.5 (new, at the start of `/sdrf:annotate`)**

1. Look the PXD up in `bigbio/sdrf-annotated-datasets` — the authoritative source, not the local spec copy.
2. Not there → proceed normally, no friction added to the common case.
3. **There → STOP before annotating.** Fetch the existing file and audit it.
4. Report findings and offer three explicit choices: `leave` / `fix` / `reannotate`.

**Recommend by defect class**, because "there is an existing annotation" and "the existing annotation is wrong" are different situations:

| Audit result | Recommend | Why |
|---|---|---|
| clean | `leave` | re-annotating a correct file is churn for reviewers and can regress hand curation |
| major/minor only | `fix` | a targeted diff is far easier to review and preserves existing work |
| any blocker | `reannotate` | when the file misrepresents which runs or organisms the deposit has, patching cells leaves the structure wrong |

Refusing outright (your option 1) would be wrong for a file that is genuinely broken; auto-fixing (option 2) would be wrong for a file that is merely different from what this tool would emit. The severity split is what decides between them, and the user still makes the call — `reannotate` never happens without them asking for it.

### The audit

`tools/existing_annotation.py` + `python -m tools audit-existing`. It only reports what the **deposit itself** can settle, and never judges biological interpretation:

| Check | Severity |
|---|---|
| `missing_runs` / `invented_runs` — annotation vs deposited files | blocker |
| `organism_mismatch` — organisms PRIDE registers that never appear in the SDRF | blocker |
| `counter_abuse` — `technical replicate`/`fraction identifier` used as a row index | major |
| `cv_term_no_accession` — `NT=` with no `AC=` | major |
| `no_factor_value` | major |
| `characteristics_not_bare_label`, `source_name_convention` | minor |

Two deliberate properties:

- **Missing context skips a check, it never passes it.** Omit `--runs` and coverage is *skipped*, and the CLI says so. A silent pass on an unchecked dimension is worse than no check.
- **Exit code is non-zero only for blockers**, so it can gate a workflow without failing on convention drift.

### Developed against a real failure

`PXD017812` is a three-species mixed-proteome benchmark (human + yeast + E. coli — its search database is explicitly all three). An automated batch annotated it as `Saccharomyces cerevisiae` on all 47 rows, missed 2 of the 49 deposited runs, and used both `fraction identifier` and `technical replicate` as 1..47 row counters. Running the audit against the file currently on `main`:

```
BLOCKER  missing_runs: 2 deposited run(s) are not annotated
BLOCKER  organism_mismatch: PRIDE registers 3 organism(s) but 2 never appear in the SDRF
MAJOR    counter_abuse: comment[technical replicate] runs 1..47 with every row distinct
MAJOR    counter_abuse: comment[fraction identifier] runs 1..47 with every row distinct
MAJOR    cv_term_no_accession: 1 CV term(s) carry NT= with no AC= accession
MAJOR    no_factor_value: the SDRF declares no factor value column
MINOR    source_name_convention: source name does not follow <ACCESSION>-Sample-<n>

suggested action: reannotate
```

Against the corrected version it reports nothing and suggests `leave`.

**Building it also caught a false positive worth flagging:** `comment[sdrf template]` and `comment[sdrf annotation tool]` legitimately use `NT=..;VV=..` with no accession, so the first version flagged *every correctly annotated file*. Both are now exempt, with a regression test — this is exactly the kind of check that is worse than useless if it cries wolf.

### Tests

16 new tests, 142 pass overall, `ruff` clean on the changed files. `tools-tests.yml` is path-filtered to `tools/**` and `tests/**`, so these do run in CI — note the `skills/**` half of this PR does not, per the repo's own CLAUDE.md.

### Not done

I did not touch `CLAUDE.md`, `GEMINI.md`, `.cursor/rules/`, `.opencode/AGENTS.md` or `.codex/INSTALL.md`. The 6-file lockstep in CLAUDE.md applies to *adding or renaming a skill*, and this adds neither — but if you'd like the new gate reflected in the per-platform instruction files, say so and I'll follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `audit-existing` command to review deposited SDRF files and provide readable findings and recommendations.
  - Audits now check run coverage, organism details, formatting, ontology terms, structure, and annotation conventions.
  - Reports categorize issues by severity and recommend leaving, fixing, or reannotating.
- **Documentation**
  - Updated annotation and contribution workflows with an explicit review checkpoint.
  - Existing annotations must be audited and user-approved before changes or reannotation.
  - Contribution guidance now records evidence when correcting prior annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->