### PR TITLE
feat(mcp): add MassIVE support to search_projects/get_project_details

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     paths:
       - 'tools/**'
+      - 'mcp/**'
       - 'tests/**'
       - 'requirements.txt'
   push:
     branches: [main]
     paths:
       - 'tools/**'
+      - 'mcp/**'
       - 'tests/**'
       - 'requirements.txt'
 

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install requests>=2.28 pytest
+          pip install requests>=2.28 pytest fastmcp>=3.4 httpx>=0.28
 
       - name: Run tests
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,8 +217,9 @@ reimplementing merge semantics.
    pass; do not trust a single multi-`--template` invocation. For the authoritative multi-template
    constraint set (column licensing + reserved-word `allow_*`), resolve with
    `spec/scripts/resolve_templates.py` — parse_sdrf enforces neither. `parse_sdrf` ships in
-   `sdrf-pipelines` and is **not installed by default** (CI installs only `requests` + `pytest`) — run
-   `/sdrf:setup`. Keep concurrent `parse_sdrf` jobs ≤ 2.
+   `sdrf-pipelines` and is **not installed by default** (CI installs only `requests`, `pytest`,
+   `fastmcp`, `httpx` — not `sdrf-pipelines[ontology]`, which is heavy) — run `/sdrf:setup`. Keep
+   concurrent `parse_sdrf` jobs ≤ 2.
 8. **A producer must never approve its own SDRF.** For changed SDRFs, require a passing receipt from
    `sdrf-adversarial-review`; any edit invalidates the receipt and requires a fresh reviewer.
    Enforced by `python -m tools review-gate` (`track`, `pending`, `status`, `gate`, `approve`), which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,11 @@ activated env. Supported: Python 3.10/3.11/3.12 (CI matrix); `environment.yml` p
 2. `tools/` — offline-first Python. Only `massive-files` (annotate, review) and `cellline lookup`
    (annotate) are ever called by a skill. `check`, `score`, `fix`, `benchmark`, and `verify` are called
    by **no skill** — reachable only by hand or from CI, which smoke-tests all subcommands.
+   `massive-files` asks MassIVE's PROXI record for the dataset's FTP root and tries it first
+   (`proxi_ftp_url`): a bare MSV yielded no root at all, and the ProteomeCentral route yields one with
+   the version directory missing, so both fell through to guessing `/v02/` and timed out on the many
+   datasets that live under `/v01/`. `fetch_json` honours the response charset for the same
+   ISO-8859-1 reason as the MCP client.
 3. `spec/` — the runtime data contract (below).
 
 **Skill dependency graph — two orchestrators.** `sdrf-autoresearch` chains
@@ -108,9 +113,9 @@ copy and the others desync silently.
 ## MCP
 
 `.mcp.json` wires the bundled `mcp/server.py` (FastMCP, name `sdrf-pride-pmc`) as a project MCP server,
-launched via `./.venv/bin/python`. It exposes 9 tools: `get_project_details`, `get_project_files`,
-`get_article_metadata`, `get_pdf_by_unpaywall`, `search`, `searchClasses`, `getChildren`,
-`get_full_text_article`, `get_full_text_section`. `fastmcp`/`httpx` are in `requirements.txt` and
+launched via `./.venv/bin/python`. It exposes 10 tools: `search_projects`, `get_project_details`,
+`get_project_files`, `get_article_metadata`, `get_pdf_by_unpaywall`, `search`, `searchClasses`,
+`getChildren`, `get_full_text_article`, `get_full_text_section`. `fastmcp`/`httpx` are in `requirements.txt` and
 `environment.yml`. **The server depends on `.venv/` existing** (`uv venv .venv && uv pip install
 --python .venv/bin/python -r requirements.txt`); conda users must repoint `command` in `.mcp.json`.
 
@@ -118,6 +123,39 @@ Skills still call **five tools that exist in no bundled server** — `searchClas
 `listEmbeddingModels`, `searchWithEmbeddingModel` (in `sdrf-terms` and `sdrf-annotate`), and
 `search_articles` / `search_preprints` (in `sdrf-brainstorm`). Those paths need an external OLS/PubMed/
 bioRxiv MCP or a rewrite onto `searchClasses`/`getChildren`.
+
+**Article identifiers must be BARE — silent-corruption class.** `get_article_metadata` and
+`get_pdf_by_unpaywall` classify with `_classify_article_id` / `_parse_identifier`, which accept a bare
+PMID (`35695565`), `PMC…`, or a bare DOI matching `^10\.\d{4,9}/…`. A prefixed `PMID:35695565` or
+`doi:10.…` is rejected and yields an **error record, not an exception** — so a skill that documents the
+prefixed form degrades every lookup to "no evidence" and reports it as low confidence. Pinned by
+`tests/test_mcp_pride.py`.
+
+**`get_project_details` / `search_projects` span PRIDE *and* MassIVE.** `MSV…` routes to MassIVE's
+PROXI API; `PXD…` tries PRIDE then falls back to MassIVE, because MassIVE-hosted ProteomeXchange
+datasets **404 in PRIDE** (`PXD003626` is a live example) — a PXD prefix is not evidence of PRIDE
+residency. Results carry `repository` and `all_accessions` (a dataset may hold both an MSV and a PXD;
+dedupe on it). MassIVE metadata is far thinner — measured over 100 datasets each: instruments
+PRIDE 100% / MassIVE 3%, `experiment_types` and `quantification_methods` never published by MassIVE
+(PRIDE 100% / 14%). Screen MassIVE candidates from the publication; empty ≠ excluded.
+
+**PROXI parsing has three traps, all silent** — payload is in `value` not `name`; species /
+publications / contacts nest one list deeper; and a missing value is often the literal string
+`"null"`. `_proxi_values()` is the single place all three are handled — do not hand-roll PROXI parsing
+elsewhere.
+
+**MassIVE serves `charset=ISO-8859-1`.** `httpx.Response.json()` decodes raw bytes as UTF-8, so one
+accented character (author names, European affiliations) raised `UnicodeDecodeError` and silently
+dropped a whole result page — 29% recall loss on a measured query. `_cached_get_json` now falls back
+to `json.loads(resp.text)`, which honours the declared charset. It also takes `not_found_ok=True` to
+map a 404 to `[]`, because MassIVE 404s when you page past the end and that is exhaustion, not failure.
+
+**PRIDE keyword search ANDs its terms.** `search_projects(keyword=…)` narrows hard on multi-word input
+(`metaproteomics` → 100+, `human gut metaproteomics` → 2). Issue several short keywords and union the
+accessions. PRIDE hits return the structured fields as **plain strings**, where `get_project_details`
+returns **CvParam dicts** for the same logical fields; `_names()` handles both. On MassIVE's PROXI,
+`resultType` is required, `pageNumber` is 1-based, and **`keywords=` is silently ignored** — it returns
+the unfiltered listing, so only `search=` actually filters.
 
 ## Spec data contract (`spec/`, read at runtime — never hardcode)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The repository contains 20 skills. The established domain workflows use the
 | `/sdrf:setup` | Install dependencies (parse_sdrf, techsdrf) — conda or pip guided setup |
 | `/sdrf:knowledge` | Ask about SDRF format, column rules, ontology mappings, reserved words |
 | `/sdrf:templates` | Ask about templates, select templates, understand layers and selection rules |
-| `/sdrf:metascreen` | Screen/shortlist PRIDE, MassIVE, or ProteomeXchange studies against user criteria → evidence-backed TSV |
+| `/sdrf:metascreen` | Screen/shortlist PRIDE, MassIVE, or ProteomeXchange studies against user criteria → evidence-backed, resumable TSV |
 | `/sdrf:autoresearch` | Autonomous retained-improvement loop over a dataset, manifest, or dataset class |
 | `/sdrf:annotate` | Full annotation workflow: PXD → PRIDE + paper → draft SDRF → validate |
 | `/sdrf:validate` | Systematic validation against templates + ontology checking via OLS |

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -147,12 +147,15 @@ def _resolve_publication(pmid: str | None, doi: str | None, reference: str) -> d
 _PROXI_EMPTY = {"", "null", "none", "n/a", "na"}
 
 
-def _proxi_values(record: dict, key: str) -> list[str]:
-    """Flatten a PROXI CvParam field to real string values, dropping empties."""
-    out: list[str] = []
+def _proxi_cv_groups(record: dict, key: str) -> list[list[dict]]:
+    """Normalize a PROXI CvParam field into its item groups, each a list of
+    {accession, value} dicts with non-dict junk and empty/null values dropped.
+    The single place that handles all three PROXI parsing traps described
+    above — `_proxi_values()` and `_proxi_publications()` both build on it."""
+    groups: list[list[dict]] = []
     for entry in record.get(key, []) or []:
-        group = entry if isinstance(entry, list) else [entry]
-        for cv in group:
+        cleaned: list[dict] = []
+        for cv in (entry if isinstance(entry, list) else [entry]):
             if not isinstance(cv, dict):
                 continue
             val = cv.get("value")
@@ -161,31 +164,29 @@ def _proxi_values(record: dict, key: str) -> list[str]:
             val = str(val).strip()
             if val.lower() in _PROXI_EMPTY:
                 continue
-            out.append(val)
-    return out
+            cleaned.append({"accession": cv.get("accession"), "value": val})
+        groups.append(cleaned)
+    return groups
+
+
+def _proxi_values(record: dict, key: str) -> list[str]:
+    """Flatten a PROXI CvParam field to real string values, dropping empties."""
+    return [cv["value"] for group in _proxi_cv_groups(record, key) for cv in group]
 
 
 def _proxi_publications(record: dict) -> list[dict]:
     """Resolve PROXI publication CvParams into the PRIDE publication shape."""
     publications: list[dict] = []
-    for group in record.get("publications", []) or []:
-        entries = group if isinstance(group, list) else [group]
+    for group in _proxi_cv_groups(record, "publications"):
         pmid = doi = None
         reference = ""
-        for cv in entries:
-            if not isinstance(cv, dict):
-                continue
-            val = cv.get("value")
-            if val is None or str(val).strip().lower() in _PROXI_EMPTY:
-                continue
-            val = str(val).strip()
-            acc = cv.get("accession")
-            if acc == "MS:1000879":       # PubMed identifier
-                pmid = val
-            elif acc == "MS:1001922":     # Digital Object Identifier
-                doi = val
-            elif acc == "MS:1002866":     # Reference
-                reference = val
+        for cv in group:
+            if cv["accession"] == "MS:1000879":       # PubMed identifier
+                pmid = cv["value"]
+            elif cv["accession"] == "MS:1001922":     # Digital Object Identifier
+                doi = cv["value"]
+            elif cv["accession"] == "MS:1002866":     # Reference
+                reference = cv["value"]
         if not (pmid or doi or reference):
             continue
         if pmid or doi:
@@ -366,6 +367,7 @@ def search_projects(
                 if any(a in seen for a in hit["all_accessions"]):
                     continue  # already covered by the richer PRIDE record
                 results.append(hit)
+                seen.update(a for a in hit["all_accessions"] if a)
 
     out = {
         "keyword": keyword,

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -8,6 +8,7 @@ Implements tools for SDRF annotation workflow:
 - OLS: ontology term search for SDRF column annotation
 """
 
+import json
 import os
 import re
 import threading
@@ -21,10 +22,11 @@ import httpx
 
 mcp = FastMCP(
     "sdrf-pride-pmc",
-    instructions="PRIDE, Europe PMC, Unpaywall, and OLS tools for SDRF annotation workflow",
+    instructions="PRIDE, MassIVE, Europe PMC, Unpaywall, and OLS tools for SDRF annotation workflow",
 )
 
 PRIDE_BASE = "https://www.ebi.ac.uk/pride/ws/archive/v2"
+MASSIVE_BASE = "https://massive.ucsd.edu/ProteoSAFe/proxi/v0.1"
 EUROPE_PMC_BASE = "https://www.ebi.ac.uk/europepmc/webservices/rest"
 OLS_BASE = "https://www.ebi.ac.uk/ols4/api"
 UNPAYWALL_BASE = "https://api.unpaywall.org/v2"
@@ -64,9 +66,18 @@ _CACHE_MAX = 512
 
 
 def _cached_get_json(
-    url: str, params: dict | None = None, timeout: float | None = None
+    url: str,
+    params: dict | None = None,
+    timeout: float | None = None,
+    not_found_ok: bool = False,
 ) -> dict | None:
-    """GET → JSON with process-local caching. Returns None on non-200 or network error."""
+    """GET → JSON with process-local caching. Returns None on non-200 or network error.
+
+    `not_found_ok=True` maps a 404 to `[]` instead of None, so callers can tell
+    "nothing there" apart from "request failed". MassIVE's PROXI search 404s when
+    you page past the last page; without this the two are indistinguishable and a
+    transient failure looks like the end of the result set.
+    """
     key = url + "|" + repr(sorted((params or {}).items()))
     hit = _json_cache.get(key)
     if hit is not None:
@@ -76,8 +87,16 @@ def _cached_get_json(
             url, params=params, timeout=timeout or _DEFAULT_TIMEOUT
         )
         if resp.status_code != 200:
-            return None
-        data = resp.json()
+            return [] if (not_found_ok and resp.status_code == 404) else None
+        try:
+            data = resp.json()
+        except UnicodeDecodeError:
+            # httpx .json() decodes the raw bytes as UTF-8. MassIVE serves
+            # `application/json;charset=ISO-8859-1`, so any record carrying an
+            # accented character (author names, European affiliations) blows up
+            # and would silently drop a whole page. .text honours the declared
+            # charset — decode through it instead.
+            data = json.loads(resp.text)
     except Exception:
         return None
     if len(_json_cache) >= _CACHE_MAX:
@@ -115,6 +134,272 @@ def _resolve_publication(pmid: str | None, doi: str | None, reference: str) -> d
     }
 
 
+# -----------------------------------------------------------------------------
+# MassIVE (PROXI) adapter.
+#
+# MassIVE serves the PROXI standard, whose records differ from PRIDE's in three
+# ways that all corrupt silently if ignored:
+#   1. the payload sits in `value`, not `name` (`name` is the CV term label)
+#   2. species / publications / contacts are nested one list deeper
+#   3. a missing value is often the literal STRING "null", not JSON null
+# _proxi_values() is the single place all three are handled.
+# -----------------------------------------------------------------------------
+_PROXI_EMPTY = {"", "null", "none", "n/a", "na"}
+
+
+def _proxi_values(record: dict, key: str) -> list[str]:
+    """Flatten a PROXI CvParam field to real string values, dropping empties."""
+    out: list[str] = []
+    for entry in record.get(key, []) or []:
+        group = entry if isinstance(entry, list) else [entry]
+        for cv in group:
+            if not isinstance(cv, dict):
+                continue
+            val = cv.get("value")
+            if val is None:
+                continue
+            val = str(val).strip()
+            if val.lower() in _PROXI_EMPTY:
+                continue
+            out.append(val)
+    return out
+
+
+def _proxi_publications(record: dict) -> list[dict]:
+    """Resolve PROXI publication CvParams into the PRIDE publication shape."""
+    publications: list[dict] = []
+    for group in record.get("publications", []) or []:
+        entries = group if isinstance(group, list) else [group]
+        pmid = doi = None
+        reference = ""
+        for cv in entries:
+            if not isinstance(cv, dict):
+                continue
+            val = cv.get("value")
+            if val is None or str(val).strip().lower() in _PROXI_EMPTY:
+                continue
+            val = str(val).strip()
+            acc = cv.get("accession")
+            if acc == "MS:1000879":       # PubMed identifier
+                pmid = val
+            elif acc == "MS:1001922":     # Digital Object Identifier
+                doi = val
+            elif acc == "MS:1002866":     # Reference
+                reference = val
+        if not (pmid or doi or reference):
+            continue
+        if pmid or doi:
+            publications.append(_resolve_publication(pmid, doi, reference))
+        else:
+            publications.append({
+                "pmid": None, "pmcid": None, "doi": None,
+                "is_open_access": False, "reference": reference,
+            })
+    return publications
+
+
+def _massive_to_project(record: dict, queried: str | None = None) -> dict:
+    """Map a MassIVE PROXI dataset record onto the get_project_details schema."""
+    accessions = _proxi_values(record, "accession")
+    primary = queried or next(
+        (a for a in accessions if a.upper().startswith("PXD")),
+        accessions[0] if accessions else None,
+    )
+    return {
+        "accession": primary,
+        "all_accessions": accessions,
+        "repository": "MassIVE",
+        "title": record.get("title"),
+        "description": record.get("summary"),
+        # MassIVE PROXI exposes no protocol text and no experiment/quantification
+        # CV terms. Empty is honest here — screen these from the publication.
+        "sample_processing_protocol": None,
+        "data_processing_protocol": None,
+        "organism": _proxi_values(record, "species"),
+        "organism_parts": [],
+        "countries": [],
+        "instruments": _proxi_values(record, "instruments"),
+        "experiment_types": [],
+        "quantification_methods": [],
+        "modifications": _proxi_values(record, "modifications"),
+        "publications": _proxi_publications(record),
+        "keywords": _proxi_values(record, "keywords"),
+    }
+
+
+def _massive_search_hit(record: dict) -> dict:
+    """Cheap projection of a PROXI search hit — NOT _massive_to_project().
+
+    A search page returns up to `page_size` records and none of them expose
+    `publications` in the output shape, so resolving publications here (a live
+    Europe PMC call per record, via _proxi_publications) would be pure waste —
+    measured at 17 discarded Europe PMC requests for one 30-record page. Only
+    compute what a search hit actually reports.
+    """
+    accessions = _proxi_values(record, "accession")
+    return {
+        "accession": next((a for a in accessions if a.upper().startswith("PXD")),
+                          accessions[0] if accessions else None),
+        "all_accessions": accessions,
+        "repository": "MassIVE",
+        "title": record.get("title"),
+        "description": record.get("summary"),
+        "organism": _proxi_values(record, "species"),
+        "organism_parts": [],
+        "instruments": _proxi_values(record, "instruments"),
+        "experiment_types": [],
+        "quantification_methods": [],
+        "keywords": _proxi_values(record, "keywords"),
+        "publication_date": None,
+        "has_sdrf": False,
+    }
+
+
+def _massive_get_dataset(accession: str) -> dict | None:
+    """Fetch one MassIVE dataset by MSV… or PXD… accession."""
+    data = _cached_get_json(f"{MASSIVE_BASE}/datasets/{accession}")
+    if isinstance(data, dict) and data.get("title"):
+        return data
+    # Direct path can 200 with an empty body for unknown ids; the accession
+    # filter is the reliable confirmation.
+    hits = _cached_get_json(
+        f"{MASSIVE_BASE}/datasets",
+        params={"resultType": "full", "accession": accession},
+    )
+    if isinstance(hits, list) and hits:
+        return hits[0]
+    return None
+
+
+# --- 1.0 Search projects across PRIDE + MassIVE (discovery) ---
+@mcp.tool()
+def search_projects(
+    keyword: str,
+    page_size: int = 100,
+    page: int = 0,
+    repository: str = "all",
+) -> dict:
+    """
+    Search proteomics projects by keyword across PRIDE and MassIVE. Use this to
+    resolve a free-text dataset category ("human gut metaproteomics") into
+    concrete accessions.
+
+    `repository`: "all" (default, both), "pride", or "massive".
+
+    Each hit carries the structured screening fields, so a candidate set can be
+    pre-filtered on organism / instrument / experiment_types /
+    quantification_methods WITHOUT one get_project_details call per hit. Fetch
+    details only for survivors. Each hit reports its `repository`.
+
+    MassIVE hits carry BOTH accessions (`all_accessions`: MSV… and, when the
+    dataset is in ProteomeXchange, PXD…). Results are deduplicated on any shared
+    accession, preferring the PRIDE copy because MassIVE PROXI publishes no
+    experiment_types, quantification_methods, organism_parts or countries.
+
+    Keyword behaviour (measured, not documented upstream): PRIDE ANDs the terms
+    and narrows HARD — "metaproteomics" returns 100+, "human gut metaproteomics"
+    returns 2. For recall, issue several SHORT keyword searches and union the
+    accessions; do not pass a whole category sentence as one keyword. Hits are
+    ranked, not filtered, so always re-check the structured fields yourself.
+
+    Results cap at `page_size` per call; page through until a call returns fewer
+    than `page_size` hits.
+
+    Returns {keyword, repository, page, page_size, count, results:[{accession,
+    all_accessions, repository, title, description, organism, organism_parts,
+    instruments, experiment_types, quantification_methods, keywords,
+    publication_date, has_sdrf}], errors:[...]}.
+    """
+    repo = (repository or "all").lower().strip()
+    if repo not in {"all", "pride", "massive"}:
+        return {"keyword": keyword, "count": 0, "results": [],
+                "error": f"repository must be all|pride|massive, got {repository!r}"}
+
+    results: list[dict] = []
+    errors: list[str] = []
+
+    def _names(rec: dict, key: str) -> list[str]:
+        # /search/projects returns plain strings where /projects/{acc} returns
+        # CvParam dicts for the same logical field. Accept both.
+        out = []
+        for v in rec.get(key, []) or []:
+            out.append(v.get("name", "") if isinstance(v, dict) else str(v))
+        return out
+
+    if repo in {"all", "pride"}:
+        data = _cached_get_json(
+            f"{PRIDE_BASE}/search/projects",
+            params={"keyword": keyword, "pageSize": str(page_size), "page": str(page)},
+        )
+        if data is None:
+            errors.append("PRIDE search unreachable")
+            items = []
+        else:
+            items = data if isinstance(data, list) else (
+                data.get("_embedded", {}).get("compactprojects", []) or []
+            )
+        for it in items:
+            results.append(_pride_search_hit(it, _names))
+
+    if repo in {"all", "massive"}:
+        # PROXI requires resultType; `keywords=` is silently IGNORED and returns
+        # the unfiltered listing — `search=` is the only real filter. pageNumber
+        # is 1-based (`page=` is ignored). Paging past the end 404s, which
+        # not_found_ok maps to [] so it reads as exhaustion, not failure.
+        mparams = {
+            "resultType": "full",
+            "search": keyword,
+            "pageSize": str(page_size),
+            "pageNumber": str(page + 1),
+        }
+        mdata = _cached_get_json(
+            f"{MASSIVE_BASE}/datasets", params=mparams, not_found_ok=True
+        )
+        if mdata is None:
+            errors.append(
+                f"MassIVE search failed for page {page} — results are INCOMPLETE, retry this page"
+            )
+        else:
+            seen = {a for r in results for a in r["all_accessions"] if a}
+            for rec in mdata if isinstance(mdata, list) else []:
+                hit = _massive_search_hit(rec)
+                if any(a in seen for a in hit["all_accessions"]):
+                    continue  # already covered by the richer PRIDE record
+                results.append(hit)
+
+    out = {
+        "keyword": keyword,
+        "repository": repo,
+        "page": page,
+        "page_size": page_size,
+        "count": len(results),
+        "results": results,
+    }
+    if errors:
+        out["errors"] = errors
+    return out
+
+
+def _pride_search_hit(it: dict, _names) -> dict:
+    acc = it.get("accession")
+    return {
+            "accession": acc,
+            "all_accessions": [acc] if acc else [],
+            "repository": "PRIDE",
+            "title": it.get("title"),
+            "description": it.get("projectDescription"),
+            "organism": _names(it, "organisms"),
+            # search spells this "organismsPart"; project details uses "organismParts"
+            "organism_parts": _names(it, "organismsPart") or _names(it, "organismParts"),
+            "instruments": _names(it, "instruments"),
+            "experiment_types": _names(it, "experimentTypes"),
+            "quantification_methods": _names(it, "quantificationMethods"),
+            "keywords": it.get("keywords", []),
+            "publication_date": it.get("publicationDate"),
+            "has_sdrf": bool(it.get("sdrf")),
+    }
+
+
 # --- 1.1 Get PRIDE project metadata ---
 @mcp.tool()
 def get_project_details(project_accession: str) -> dict:
@@ -128,19 +413,48 @@ def get_project_details(project_accession: str) -> dict:
       - otherwise (pmid and/or doi set)   → get_article_metadata(ids=[<any-id>])
       - nothing set                       → ask the user for the publication.
 
-    Returns: title, description, sample_processing_protocol, data_processing_protocol,
-    organism, instruments, modifications, publications, keywords.
+    Resolves across BOTH repositories, so callers need no routing logic:
+      - MSV…  → MassIVE
+      - PXD…  → PRIDE, falling back to MassIVE when PRIDE does not hold it
+                (MassIVE-hosted ProteomeXchange datasets 404 in PRIDE —
+                e.g. PXD003626 — so the fallback is required, not cosmetic)
+
+    Returns: accession, all_accessions, repository, title, description,
+    sample_processing_protocol, data_processing_protocol, organism,
+    organism_parts, countries, instruments, experiment_types,
+    quantification_methods, modifications, publications, keywords.
+
+    `experiment_types` (e.g. "Shotgun proteomics") and `quantification_methods`
+    (e.g. "TIC", "TMT") are the structured screening fields — prefer them over
+    parsing the free-text protocols when filtering candidates. MassIVE PROXI
+    publishes neither, and no protocol text; those come back empty and must be
+    screened from the publication instead. An empty field is not a failed check.
     """
-    data = _cached_get_json(f"{PRIDE_BASE}/projects/{project_accession}")
+    accession = (project_accession or "").strip()
+
+    if accession.upper().startswith("MSV"):
+        record = _massive_get_dataset(accession)
+        if record is None:
+            return {"accession": accession,
+                    "error": "MassIVE dataset not found or API unreachable"}
+        return _massive_to_project(record, queried=accession)
+
+    data = _cached_get_json(f"{PRIDE_BASE}/projects/{accession}")
     if data is None:
+        record = _massive_get_dataset(accession)
+        if record is not None:
+            return _massive_to_project(record, queried=accession)
         return {
-            "accession": project_accession,
-            "error": "PRIDE project not found or API unreachable",
+            "accession": accession,
+            "error": "Not found in PRIDE or MassIVE, or both APIs unreachable",
         }
 
     organisms = [o.get("name", "") for o in data.get("organisms", [])]
     instruments = [i.get("name", "") for i in data.get("instruments", [])]
     mods = [m.get("name", "") for m in data.get("identifiedPTMStrings", [])]
+    organism_parts = [p.get("name", "") for p in data.get("organismParts", []) or []]
+    experiment_types = [e.get("name", "") for e in data.get("experimentTypes", []) or []]
+    quant_methods = [q.get("name", "") for q in data.get("quantificationMethods", []) or []]
 
     publications: list[dict] = []
     for r in data.get("references", []) or []:
@@ -157,12 +471,18 @@ def get_project_details(project_accession: str) -> dict:
 
     return {
         "accession": data.get("accession"),
+        "all_accessions": [data.get("accession")] if data.get("accession") else [],
+        "repository": "PRIDE",
         "title": data.get("title"),
         "description": data.get("projectDescription"),
         "sample_processing_protocol": data.get("sampleProcessingProtocol"),
         "data_processing_protocol": data.get("dataProcessingProtocol"),
         "organism": organisms,
+        "organism_parts": organism_parts,
+        "countries": data.get("countries", []),
         "instruments": instruments,
+        "experiment_types": experiment_types,
+        "quantification_methods": quant_methods,
         "modifications": mods,
         "publications": publications,
         "keywords": data.get("keywords", []),

--- a/skills/sdrf-metascreen/SKILL.md
+++ b/skills/sdrf-metascreen/SKILL.md
@@ -2,7 +2,7 @@
 name: sdrf:metascreen
 description: Use before sdrf:autoresearch when the user needs to screen or shortlist proteomics studies from PRIDE, MassIVE, or ProteomeXchange accessions, or from a manifest, using detailed user-defined inclusion/exclusion criteria; extract study-level metadata from repository records and publications; and write an evidence-backed, resumable TSV for downstream annotation, review, or meta-analysis.
 user-invocable: true
-argument-hint: 'target="<all PRIDE|MassIVE ...|accessions:PXD...,MSV...|path/to/accessions.txt|path/to/manifest.tsv>" [criteria="<md|txt|inline>"] [extract="<cols|txt|md>"] [output="results.tsv"]'
+argument-hint: 'target="<all PRIDE|MassIVE ...|accessions:PXD...,MSV...|path/to/accessions.txt|path/to/manifest.tsv>" [criteria="<md|txt|inline>"] [extract="<cols|txt|md>"] [output="results.tsv"] [dig_passes=1]'
 ---
 
 # SDRF Meta-Analysis Screening Protocol
@@ -89,6 +89,12 @@ report each name dropped.
 ### `output`
 Path for the output TSV. Default: `metascreen_results.tsv`
 
+### `dig_passes`
+Integer, default `1`. How many extra evidence-gathering rounds (3.5) to spend
+on an accession that would otherwise land on `uncertain` or an `unclear`
+extract field, before finalizing the row. `0` disables the extra round —
+finalize on the first pass, same as always taking the first answer.
+
 ---
 
 State the resolved config before processing begins:
@@ -97,6 +103,7 @@ Target     : <resolved description>
 Criteria   : <source or "none">
 Extract    : <resolved column list>
 Output     : <path>
+Dig passes : <N>
 Resuming   : <N already screened | fresh run>
 ```
 
@@ -195,12 +202,15 @@ evidence the record is in PRIDE. Each result reports its `repository`, and
 Record the `repository` value in its own output column, and use `all_accessions`
 to avoid screening the same study twice under its two accessions.
 
-Read all fields. The structured fields from the table above are the most
-reliable; `sample_processing_protocol` and `data_processing_protocol` are
+Read all fields the tool returns, not just the ones in the pre-filter table
+above — that table is scoped to what `search_projects` exposes for Step 2's
+purpose, and `get_project_details` returns more. Check the full result against
+whatever the `extract` request actually asks for. Structured fields are the
+most reliable; `sample_processing_protocol` and `data_processing_protocol` are
 free text but are often the highest-signal source for anything the structured
-fields omit. **MassIVE records have no protocol text and no experiment or
-quantification terms** — for those, the publication is the only evidence source,
-so go straight to 3.2.
+fields omit. **MassIVE records have far fewer structured fields and no protocol
+text** — for those, the publication is the only evidence source, so go straight
+to 3.2.
 
 If the tool returns an `error` key, the accession is in neither repository. Do
 not retry and do not invent metadata — go to 3.2 and screen from the publication
@@ -291,7 +301,33 @@ Extract fields for `exclude` rows too when the evidence is already in hand — i
 costs nothing and makes the exclusion tally analysable. Never fetch extra
 publications just to fill fields on an excluded row.
 
-### 3.5 Append the row and print progress
+### 3.5 Dig deeper before settling for uncertain or unclear
+
+Applies only when the row so far has `label: uncertain` or at least one
+`unclear` extract field, and only when the label is not `exclude` — an
+excluded row is already decided, and 3.4 already says not to spend extra
+fetches filling its fields.
+
+Spend up to `dig_passes` extra rounds per accession before finalizing. One
+round means: go back and look harder at evidence you may have skimmed or
+never explicitly requested, for example —
+- Re-read the full repository record from 3.1, field by field, and the full
+  `sample_processing_protocol` / `data_processing_protocol` text — don't skim
+  past a field or a sentence because it looked like lab-protocol boilerplate.
+- If 3.2 only ever fetched the default methods-filtered sections, call
+  `get_full_text_article(mode="toc")` to see the full section list, then
+  `get_full_text_section` on any section name that could plausibly hold the
+  missing evidence but didn't match the default keyword filter.
+- If there is a DOI or PMID but no PMCID full text was tried yet, try
+  `get_pdf_by_unpaywall` (3.2).
+
+Then redo 3.3 and 3.4 with whatever new evidence turned up. After `dig_passes`
+rounds (or immediately, if `dig_passes` is `0`), finalize the row as-is —
+don't retry a source that has already been exhausted (e.g. a full-text fetch
+that already returned an error), since that spends the budget without a
+chance of new evidence.
+
+### 3.6 Append the row and print progress
 
 Append the row to the output file **now** (see Step 4) — do not accumulate rows
 in memory until the end. Then print:
@@ -344,6 +380,8 @@ run_date        : <ISO 8601>
 target          : <verbatim target argument>
 criteria_source : <path or "inline">
 criteria_sha256 : <sha256 of the criteria file, or "n/a" for inline>
+dig_passes      : <configured N>  (recovered: N rows where digging changed
+                  an uncertain label or unclear field)
 repositories    : <PRIDE+MassIVE | PRIDE | MassIVE>
 keywords        : <the keyword searches issued, if discovery was used>
 discovered      : N  (PRIDE N, MassIVE N)

--- a/skills/sdrf-metascreen/SKILL.md
+++ b/skills/sdrf-metascreen/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: sdrf:metascreen
-description: Use before sdrf:autoresearch when the user needs to screen or shortlist proteomics studies from PRIDE, MassIVE, ProteomeXchange accessions, or a manifest using detailed user-defined inclusion/exclusion criteria; extract study-level metadata from repository records and publications; and write an evidence-backed TSV for downstream annotation, review, or meta-analysis.
+description: Use before sdrf:autoresearch when the user needs to screen or shortlist proteomics studies from PRIDE, MassIVE, or ProteomeXchange accessions, or from a manifest, using detailed user-defined inclusion/exclusion criteria; extract study-level metadata from repository records and publications; and write an evidence-backed, resumable TSV for downstream annotation, review, or meta-analysis.
 user-invocable: true
-argument-hint: 'target="<all PRIDE ...|accessions:PXD...,MSV...|path/to/accessions.txt|path/to/manifest.tsv>" [criteria="<md|txt|inline>"] [extract="<cols|txt|md>"] [output="results.tsv"]'
+argument-hint: 'target="<all PRIDE|MassIVE ...|accessions:PXD...,MSV...|path/to/accessions.txt|path/to/manifest.tsv>" [criteria="<md|txt|inline>"] [extract="<cols|txt|md>"] [output="results.tsv"]'
 ---
 
 # SDRF Meta-Analysis Screening Protocol
 
-You are screening proteomics datasets before annotation or autoresearch.
-Your job is to resolve a candidate study set, read repository metadata and the
-associated publication for each candidate, apply the user's inclusion criteria,
-extract requested study-level metadata, and write one TSV row per accession.
+You are screening datasets before annotation or autoresearch. Your job is to
+resolve a candidate study set, read repository metadata and the associated
+publication for each candidate, apply the user's inclusion criteria, extract
+requested study-level metadata, and write one TSV row per accession.
 
 Do not guess. Use the MCP tools to verify every field.
 
@@ -18,6 +18,11 @@ This skill is complementary to `sdrf:autoresearch`: run it first when the user
 needs a more precise, publication-aware study screen before deciding which
 datasets should enter annotation. This skill produces a curation TSV; it does
 not create, validate, fix, or improve SDRF files.
+
+**The criteria and the extract fields come from the user, not from this file.**
+Nothing here is specific to any one research question — the PRIDE fields named
+in Step 2 are a worked example of "pre-filter on whatever structured fields the
+criteria actually constrain", not a fixed list.
 
 ## Step 1: Parse the Request
 
@@ -28,27 +33,39 @@ What dataset set to screen. Accepted forms:
 
 - `accessions:PXD001234,MSV000078958` — use the comma- or whitespace-separated
   accession list directly. Do not put file paths after `accessions:`.
+  Both `PXD…` and `MSV…` are supported; `get_project_details` routes to the right
+  repository on its own, so no per-accession branching is needed.
 - Any file path (`.txt`, `.tsv`, `.csv`) — resolve automatically by extension:
   - `.txt` — one accession per line, strip whitespace, skip blank lines
   - `.tsv` / `.csv` — read the first available accession column from:
     `id`, `accession`, `project_accession`, `project`, or the first column
-- `all PRIDE <category> datasets` — use PRIDE MCP search to discover matching
+- `all PRIDE <category> datasets` — use `search_projects` to discover matching
   datasets. Examples:
   - `all PRIDE human gut metaproteomics datasets`
   - `all PRIDE crosslinking datasets`
   - `all PRIDE human plasma proteomics datasets`
 
+  `search_projects` covers **PRIDE and MassIVE together** by default. Unless the
+  user explicitly scopes to one repository, search both — a category phrased as
+  "all PRIDE …" is ordinary shorthand for "all public datasets", not an
+  instruction to skip MassIVE. Pass `repository="pride"` or `"massive"` only when
+  the user actually asks for one.
+
 If a manifest contains previous labels, scores, or notes, use only the accession
 column unless the user explicitly asks to reuse those fields.
 
 When `target` is a free-text PRIDE category, resolve it into a concrete accession
-list using PRIDE MCP search before screening begins (see Step 2).
+list before screening begins (see Step 2).
 
 ### `criteria`
 Inclusion/exclusion rules. Accepted forms:
 - Path to a `.md` or `.txt` file — read the file and use its contents as the rules
 - Inline text — use directly as the rules
 - Omitted — no filtering; label all records `include` and only extract columns
+
+Number the rules as you read them (rule 1, rule 2, …), in the order they appear.
+Those numbers are what `failed_criterion` reports, so they must stay stable for
+the whole run. If the criteria file already numbers its rules, reuse its numbers.
 
 ### `extract`
 What fields to extract per record. Accepted forms:
@@ -62,9 +79,12 @@ What fields to extract per record. Accepted forms:
 When `extract` and `criteria` point to the same `.md` file, parse both the
 inclusion rules and the extraction instructions from it.
 
-Always include `id`, `label`, `reason`, and `evidence` in the output, even if
-they are not listed in `extract`. Append requested extraction columns after
-those required columns.
+Always include `id`, `repository`, `label`, `reason`, `failed_criterion`, and
+`evidence` in the output, even if they are not listed in `extract`. Append
+requested extraction columns after those required columns. **Discard any
+`extract` name that collides
+with a required column** (case-insensitive) — never emit a duplicate header — and
+report each name dropped.
 
 ### `output`
 Path for the output TSV. Default: `metascreen_results.tsv`
@@ -77,6 +97,7 @@ Target     : <resolved description>
 Criteria   : <source or "none">
 Extract    : <resolved column list>
 Output     : <path>
+Resuming   : <N already screened | fresh run>
 ```
 
 ## Step 2: Resolve the Target Set
@@ -89,26 +110,70 @@ asks; otherwise deduplicate and report the number removed.
 ### PRIDE category discovery
 For `all PRIDE <category> datasets`:
 
-1. Translate the category into repository search terms. Use repository metadata
-   from a few known examples only if needed to calibrate terminology.
+1. **Break the category into SHORT keywords.** PRIDE ANDs the terms in a
+   keyword, so a whole category sentence collapses recall — measured:
+   `metaproteomics` returns 100+ hits, `human gut metaproteomics` returns 2.
+   Issue several short searches and union the accessions.
 
-2. Search PRIDE for matching projects. Use relevant keywords from the category
-   description (sample type, organism, experiment type, etc.).
+```text
+Tool: search_projects(keyword="metaproteomics", page_size=100, page=0)
+```
 
-3. **Fast pre-filter using PRIDE metadata only** — before fetching any publications,
-   discard obvious mismatches using structured PRIDE fields:
-   - `organisms` — filter by species if the criteria specify one
-   - `experimentTypes` — filter by acquisition mode (DDA, DIA) if specified
-   - `quantificationMethods` — filter by quantification strategy if specified
-   - `instruments` — filter by instrument family if specified
+2. **Page until exhausted.** A call returning exactly `page_size` hits means
+   there are probably more; increment `page` until a call returns fewer.
+   If a page comes back with an `errors` entry, that page was **lost, not
+   empty** — the result set is incomplete. Retry it, and if it still fails, say
+   so in the run log rather than reporting the screen as complete.
 
-   This avoids spending publication-fetch calls on clear non-candidates.
+3. **Fast pre-filter on the structured fields the criteria constrain** — before
+   fetching any publication, discard obvious mismatches. `search_projects`
+   returns these on every hit, so this costs no extra calls:
 
-4. Report the discovered and pre-filtered candidate list before publication
-   screening:
+   | Field | Use it to filter on |
+   |---|---|
+   | `organism` | species |
+   | `organism_parts` | tissue / sample type |
+   | `instruments` | instrument model or family |
+   | `experiment_types` | acquisition mode, e.g. `Data-dependent acquisition` |
+   | `quantification_methods` | labelling strategy, e.g. `TIC`, `TMT` |
+   | `keywords` | submitter-supplied topic terms |
+
+   Filter only on fields the criteria actually constrain — skip the rest. If the
+   criteria constrain something with no structured field, that check belongs in
+   Step 3, not here.
+
+   These fields are submitter-supplied and often **empty**. An empty field is not
+   a failed check: never exclude on a missing value, carry the candidate forward
+   and decide from the publication in Step 3.
+
+   **How much pre-filtering you actually get depends on the repository.** Measured
+   over 100 datasets each:
+
+   | Field | PRIDE | MassIVE |
+   |---|---|---|
+   | `instruments` | 100% | 3% |
+   | `experiment_types` (DDA/DIA) | 100% | never published |
+   | `quantification_methods` | 14% | never published |
+   | `organism` | high | 16% |
+
+   So: instrument and acquisition can be pre-filtered in PRIDE, but **labelling
+   strategy almost never can, in either repository**, and for MassIVE the
+   structured pre-filter barely applies at all. Expect nearly every MassIVE
+   candidate to reach Step 3 and be decided from the publication. That is the
+   correct outcome — do not compensate by excluding MassIVE records for having
+   thin metadata, and do not treat a MassIVE hit as lower quality because its
+   fields are empty.
+
+   **Match these values exactly, never by substring.** `"Data-independent
+   acquisition"` contains the substring `"dependent"`, so a substring test for
+   DDA silently admits every DIA study — an inclusion error that survives to the
+   final table because nothing downstream re-checks it. Compare whole values.
+
+4. Report the counts — this is the title/abstract stage of the screen, and its
+   numbers belong in the run log:
    ```
-   Discovered : N datasets matching "<category>"
-   Pre-filtered: N remaining after PRIDE metadata check
+   Discovered  : N unique datasets across K keyword searches
+   Pre-filtered: N remaining after structured-field check (M dropped)
    ```
 
 ## Step 3: Screen Each Candidate
@@ -118,45 +183,89 @@ Process each accession in the working list independently.
 ### 3.1 Fetch repository metadata
 
 ```text
-Tool: get_project_details(project_accession="PXD######")
+Tool: get_project_details(project_accession="PXDXXXXXX")
 ```
 
-Read all fields. Pay close attention to free-text protocol fields —
-they are often the highest-signal source for instrument, acquisition,
-sample type, quantification, and study design information.
+Works for `PXD…` and `MSV…` alike. The tool resolves MSV accessions at MassIVE,
+and falls back to MassIVE for PXD accessions PRIDE does not hold — MassIVE-hosted
+ProteomeXchange datasets 404 in PRIDE (e.g. `PXD003626`), so a PXD is **not**
+evidence the record is in PRIDE. Each result reports its `repository`, and
+`all_accessions` carries both identifiers when a dataset has an MSV and a PXD.
+
+Record the `repository` value in its own output column, and use `all_accessions`
+to avoid screening the same study twice under its two accessions.
+
+Read all fields. The structured fields from the table above are the most
+reliable; `sample_processing_protocol` and `data_processing_protocol` are
+free text but are often the highest-signal source for anything the structured
+fields omit. **MassIVE records have no protocol text and no experiment or
+quantification terms** — for those, the publication is the only evidence source,
+so go straight to 3.2.
+
+If the tool returns an `error` key, the accession is in neither repository. Do
+not retry and do not invent metadata — go to 3.2 and screen from the publication
+alone; if there is no publication either, label `uncertain` and say the record
+was unreachable.
 
 ### 3.2 Fetch the publication
 
-Use publication identifiers in the repository record first. If no identifier is
-available, search by project title and authors.
+`get_project_details` returns `publications`, a list of
+`{pmid, pmcid, doi, is_open_access, reference}`. Route on those fields:
+
+**Open access with a PMCID — prefer this path.** It returns section-scoped JATS
+text and already defaults to methods/materials/sample-prep, excluding Results
+and Discussion:
 
 ```text
-Tool: get_article_metadata(ids=["PMID:XXXXXXX"])
+Tool: get_full_text_article(pmc_ids=["PMC9174028"])
 ```
 
-If the paper is open access, fetch the full text:
+To pull one more section by name, or to check what sections exist:
 
 ```text
-Tool: get_pdf_by_unpaywall(identifiers=["doi:10.xxxx/xxxxx"])
+Tool: get_full_text_section(pmc_id="PMC9174028", section="methods")
 ```
 
-Read the Methods section for any information relevant to the criteria and the
-requested extract fields. Use repository protocols, the abstract, and title only
-as fallback evidence when full text is unavailable.
+**Otherwise, metadata only** (title, abstract, OA status):
 
-If no open-access full text is available, do not infer missing eligibility
-details from vague title or keyword matches. Use `uncertain` when the evidence is
-not sufficient.
+```text
+Tool: get_article_metadata(ids=["35695565"])
+```
+
+**Identifiers must be BARE.** `get_article_metadata` accepts a bare PMID
+(`35695565`), a PMCID (`PMC9174028`), or a bare DOI (`10.1038/s41467-022-30310-x`).
+A prefixed form such as `PMID:35695565` or `doi:10.1038/...` is **rejected** and
+returns an error record, not an article — which then looks like missing evidence.
+The same applies to `get_pdf_by_unpaywall(identifiers=["10.1038/s41467-022-30310-x"])`;
+pass the bare DOI, never `doi:`-prefixed.
+
+Fall back to `get_pdf_by_unpaywall` only when there is no PMCID full text and the
+abstract is insufficient.
+
+If the repository record carries no publication identifier, search by project
+title and authors. If that fails, screen from repository metadata alone and say
+so in `evidence`.
+
+Read the Methods for anything relevant to the criteria and the requested extract
+fields. Use repository protocols, abstract, and title only as fallback evidence.
+
+If no full text is available, do not infer missing eligibility details from vague
+title or keyword matches. Use `uncertain`.
 
 ### 3.3 Apply the inclusion criteria
 
 If `criteria` was provided:
-- Apply each rule in order
+- Apply each rule in order, by its Step 1 number
 - `include` — all required inclusion rules pass and no exclusion rule applies
-- `exclude` — at least one exclusion rule clearly applies; record the decisive
-  failed rule as `reason`
+- `exclude` — at least one exclusion rule clearly applies. Record the **first**
+  failed rule's number in `failed_criterion` and its one-sentence decisive factor
+  in `reason`. Stop at the first failure; do not evaluate the rest.
 - `uncertain` — the study may be relevant, but repository metadata and available
-  publication evidence are insufficient to decide; state what is missing
+  publication evidence are insufficient to decide. Put the number of the rule you
+  could not settle in `failed_criterion` and state what evidence is missing in
+  `reason`.
+
+For `include`, leave `failed_criterion` empty.
 
 Be conservative: prefer `uncertain` over guessing when evidence is absent.
 
@@ -164,31 +273,58 @@ If `criteria` was omitted, label all records `include`.
 
 Use only these lowercase labels: `include`, `exclude`, `uncertain`.
 
+`uncertain` means **needs a human** — it is not a soft include. Do not pass
+`uncertain` rows to `sdrf:autoresearch`. Only `include` rows are cleared for
+downstream annotation.
+
 ### 3.4 Extract the requested fields
 
 For each field in the resolved `extract` list:
 - If the `extract` source provided instructions for this field, follow them exactly
 - Otherwise, infer the extraction approach from the field name and available evidence
-- Use `unclear` if the value cannot be determined from PRIDE metadata or the publication
+- Use `unclear` if the value cannot be determined from repository metadata or the
+  publication
 - Keep values short and analysis-ready. Do not paste long abstracts or methods text
   into metadata fields.
 
-### 3.5 Print progress
+Extract fields for `exclude` rows too when the evidence is already in hand — it
+costs nothing and makes the exclusion tally analysable. Never fetch extra
+publications just to fill fields on an excluded row.
 
-After each accession:
+### 3.5 Append the row and print progress
+
+Append the row to the output file **now** (see Step 4) — do not accumulate rows
+in memory until the end. Then print:
 ```
 [N/total] PXD###### → LABEL
 ```
 
 ## Step 4: Write the TSV
 
+Write incrementally, one row per accession, as each is screened.
+
+**On startup**, if the output file already exists and has a header:
+- read its `id` column, skip those accessions, and append to the file
+- report the count as `Resuming` in the Step 1 config block
+- if the existing header does not match the header this run would write, stop and
+  ask the user rather than appending mismatched rows
+
+Otherwise write the header first, then append.
+
+Format rules:
 - First row: column headers, with `id` always first
-- Required columns: `id`, `label`, `reason`, `evidence`
-- One row per accession in the order processed
-- Tab-separated, UTF-8
-- Use `unclear` for any field that could not be determined
-- In `evidence`, cite the evidence source briefly, e.g. `PRIDE protocol`,
-  `paper methods`, `abstract`, or `title/keywords only`
+- Required columns, in order: `id`, `repository`, `label`, `reason`,
+  `failed_criterion`, `evidence`
+- `id` is the accession as the user supplied it (or the primary accession from
+  discovery); `repository` is `PRIDE`, `MassIVE`, or `unclear` if neither held it
+- Tab-separated, UTF-8, one row per accession
+- **Sanitize every value**: replace tab, CR, and LF with a single space before
+  writing. Free-text `reason`, `evidence`, and extracted fields come from paper
+  methods and routinely contain them — one stray tab silently shifts every column
+  in that row and nothing errors.
+- Use `unclear` for any extract field that could not be determined
+- In `evidence`, cite the source briefly: `PRIDE structured fields`,
+  `PRIDE protocol`, `paper methods`, `abstract`, or `title/keywords only`
 
 Print a summary:
 ```
@@ -198,21 +334,49 @@ exclude:   N
 uncertain: N
 ```
 
-## Step 5: Report unresolved records
+## Step 5: Write the run log
 
-List `uncertain` accessions and state specifically what evidence was missing.
+Write a sidecar `<output>.log` (plain text, next to the TSV) so the screen is
+reproducible and can be reported as a PRISMA-style flow:
+
+```
+run_date        : <ISO 8601>
+target          : <verbatim target argument>
+criteria_source : <path or "inline">
+criteria_sha256 : <sha256 of the criteria file, or "n/a" for inline>
+repositories    : <PRIDE+MassIVE | PRIDE | MassIVE>
+keywords        : <the keyword searches issued, if discovery was used>
+discovered      : N  (PRIDE N, MassIVE N)
+pre_filtered    : N  (M dropped: <field=value counts>)
+screened        : N
+include         : N  (PRIDE N, MassIVE N)
+exclude         : N
+uncertain       : N
+lost_pages      : <none | the search pages that errored and stayed incomplete>
+exclusions_by_criterion:
+  rule 2 (Orbitrap instrument) : N
+  rule 3 (DDA acquisition)     : N
+```
+
+Build `exclusions_by_criterion` by grouping the `failed_criterion` column. This
+is why that column holds a rule number and not prose.
+
+## Step 6: Report unresolved records
+
+List `uncertain` accessions and state specifically what evidence was missing for
+each, so a human knows what to go find.
 
 ## Example invocations
 
 ```text
-# Discover from PRIDE and screen
+# Discover across PRIDE + MassIVE and screen
 /sdrf:metascreen target="all PRIDE human gut metaproteomics datasets" criteria="criteria/human_gut_metaproteomics.md" extract="criteria/human_gut_metaproteomics.md" output="results/human_gut_screen.tsv"
 
 # Fixed accession list from a txt file
 /sdrf:metascreen target="data/accessions.txt" criteria="criteria/eligibility.md" extract="instrument,acquisition,sex,age,region" output="results/screen.tsv"
 
-# Inline accessions
-/sdrf:metascreen target="accessions:PXD001234,MSV000078958" criteria="human fecal metaproteomics only; exclude animal-only studies" extract="organism,sample_type,instrument" output="results/screen.tsv"
+# Mixed PRIDE + MassIVE accessions
+/sdrf:metascreen target="accessions:PXD005969,MSV000078958" criteria="human fecal metaproteomics only; exclude animal-only studies" extract="organism,sample_type,instrument" output="results/screen.tsv"
 
 # From a manifest TSV
 /sdrf:metascreen target="data/candidates.tsv" criteria="criteria/eligibility.md" extract="criteria/extract_fields.txt" output="results/screen.tsv"
@@ -220,9 +384,19 @@ List `uncertain` accessions and state specifically what evidence was missing.
 
 ## Notes
 
-- MSV (MassIVE) accessions: PRIDE MCP may return limited metadata; use the
-  publication as the primary evidence source.
-- Never fill a field with a value not supported by evidence. Use `unclear` instead.
-- Process accessions sequentially — do not skip any.
+- **MassIVE is fully in scope.** `search_projects` and `get_project_details` both
+  cover it, and `sdrf:autoresearch` can annotate what this screen includes.
+  MassIVE records are metadata-poor, not second-class: screen them from the
+  publication and include them on the same criteria as PRIDE records.
+- A MassIVE publication usually still resolves to an open-access PMCID, so the
+  `get_full_text_article` path in 3.2 works there too — it is the main way a
+  MassIVE candidate gets decided.
+- A dataset can hold both an `MSV…` and a `PXD…` accession — see 3.1 for
+  deduplicating on `all_accessions`.
+- Never fill a field with a value not supported by evidence. Use `unclear`.
+- Process every unresolved accession — do not skip any. (Accessions already
+  present in an existing output file are resumed, not skipped.)
+- `unclear` (extract fields) and `uncertain` (label) are not interchangeable, and
+  neither is an SDRF reserved word. This skill emits a curation TSV, not an SDRF.
 - Do not run `sdrf:annotate`, `sdrf:validate`, `sdrf:fix`, or `sdrf:improve` here.
   Those belong to `sdrf:autoresearch`.

--- a/skills/sdrf-metascreen/SKILL.md
+++ b/skills/sdrf-metascreen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdrf:metascreen
-description: Use before sdrf:autoresearch when the user needs to screen or shortlist proteomics studies from PRIDE, MassIVE, or ProteomeXchange accessions, or from a manifest, using detailed user-defined inclusion/exclusion criteria; extract study-level metadata from repository records and publications; and write an evidence-backed, resumable TSV for downstream annotation, review, or meta-analysis.
+description: Use when the user needs to screen or shortlist proteomics studies from PRIDE, MassIVE, or ProteomeXchange accessions, or from a manifest, using detailed user-defined inclusion/exclusion criteria — run this before sdrf:autoresearch; extract study-level metadata from repository records and publications; and write an evidence-backed, resumable TSV for downstream annotation, review, or meta-analysis.
 user-invocable: true
 argument-hint: 'target="<all PRIDE|MassIVE ...|accessions:PXD...,MSV...|path/to/accessions.txt|path/to/manifest.tsv>" [criteria="<md|txt|inline>"] [extract="<cols|txt|md>"] [output="results.tsv"] [dig_passes=1]'
 ---
@@ -39,22 +39,23 @@ What dataset set to screen. Accepted forms:
   - `.txt` — one accession per line, strip whitespace, skip blank lines
   - `.tsv` / `.csv` — read the first available accession column from:
     `id`, `accession`, `project_accession`, `project`, or the first column
-- `all PRIDE <category> datasets` — use `search_projects` to discover matching
+- `all <category> datasets` — use `search_projects` to discover matching
   datasets. Examples:
   - `all PRIDE human gut metaproteomics datasets`
-  - `all PRIDE crosslinking datasets`
-  - `all PRIDE human plasma proteomics datasets`
+  - `all crosslinking datasets`
+  - `all human plasma proteomics datasets`
 
-  `search_projects` covers **PRIDE and MassIVE together** by default. Unless the
-  user explicitly scopes to one repository, search both — a category phrased as
-  "all PRIDE …" is ordinary shorthand for "all public datasets", not an
-  instruction to skip MassIVE. Pass `repository="pride"` or `"massive"` only when
-  the user actually asks for one.
+  `search_projects` covers **PRIDE and MassIVE together** by default. A
+  repository name inside the category phrase ("all PRIDE …") is ordinary habit,
+  not a scoping instruction — search both. Pass `repository="pride"` or
+  `"massive"` only when the user is unambiguously scoping to one, e.g. "PRIDE
+  only", "just MassIVE datasets", "skip MassIVE" — phrasing that names the
+  repository *as an exclusion*, not just in the category sentence.
 
 If a manifest contains previous labels, scores, or notes, use only the accession
 column unless the user explicitly asks to reuse those fields.
 
-When `target` is a free-text PRIDE category, resolve it into a concrete accession
+When `target` is a free-text category, resolve it into a concrete accession
 list before screening begins (see Step 2).
 
 ### `criteria`
@@ -93,12 +94,16 @@ Path for the output TSV. Default: `metascreen_results.tsv`
 Integer, default `1`. How many extra evidence-gathering rounds (3.5) to spend
 on an accession that would otherwise land on `uncertain` or an `unclear`
 extract field, before finalizing the row. `0` disables the extra round —
-finalize on the first pass, same as always taking the first answer.
+finalize on the first pass, same as always taking the first answer. Negative
+values are invalid, treat as `0`. Each round costs a handful of extra tool
+calls per accession that needs it, so it multiplies across a large target set
+— if the user asks for more than `5`, confirm they want that before running
+rather than silently burning calls on a typo.
 
 ---
 
 State the resolved config before processing begins:
-```
+```text
 Target     : <resolved description>
 Criteria   : <source or "none">
 Extract    : <resolved column list>
@@ -114,8 +119,8 @@ For `accessions:...` and file paths, resolve directly into a working list. Keep
 the original order. Preserve duplicate accessions only if the user explicitly
 asks; otherwise deduplicate and report the number removed.
 
-### PRIDE category discovery
-For `all PRIDE <category> datasets`:
+### Category discovery
+For `all <category> datasets`:
 
 1. **Break the category into SHORT keywords.** PRIDE ANDs the terms in a
    keyword, so a whole category sentence collapses recall — measured:
@@ -178,7 +183,7 @@ Tool: search_projects(keyword="metaproteomics", page_size=100, page=0)
 
 4. Report the counts — this is the title/abstract stage of the screen, and its
    numbers belong in the run log:
-   ```
+   ```text
    Discovered  : N unique datasets across K keyword searches
    Pre-filtered: N remaining after structured-field check (M dropped)
    ```
@@ -315,9 +320,9 @@ never explicitly requested, for example —
   `sample_processing_protocol` / `data_processing_protocol` text — don't skim
   past a field or a sentence because it looked like lab-protocol boilerplate.
 - If 3.2 only ever fetched the default methods-filtered sections, call
-  `get_full_text_article(mode="toc")` to see the full section list, then
-  `get_full_text_section` on any section name that could plausibly hold the
-  missing evidence but didn't match the default keyword filter.
+  `get_full_text_article(pmc_ids=[pmcid], mode="toc")` to see the full section
+  list, then `get_full_text_section` on any section name that could plausibly
+  hold the missing evidence but didn't match the default keyword filter.
 - If there is a DOI or PMID but no PMCID full text was tried yet, try
   `get_pdf_by_unpaywall` (3.2).
 
@@ -331,7 +336,7 @@ chance of new evidence.
 
 Append the row to the output file **now** (see Step 4) — do not accumulate rows
 in memory until the end. Then print:
-```
+```text
 [N/total] PXD###### → LABEL
 ```
 
@@ -363,7 +368,7 @@ Format rules:
   `PRIDE protocol`, `paper methods`, `abstract`, or `title/keywords only`
 
 Print a summary:
-```
+```text
 Saved N records to <output>
 include:   N
 exclude:   N
@@ -375,7 +380,7 @@ uncertain: N
 Write a sidecar `<output>.log` (plain text, next to the TSV) so the screen is
 reproducible and can be reported as a PRISMA-style flow:
 
-```
+```text
 run_date        : <ISO 8601>
 target          : <verbatim target argument>
 criteria_source : <path or "inline">

--- a/tests/test_massive_raw_files.py
+++ b/tests/test_massive_raw_files.py
@@ -1,5 +1,8 @@
 """Tests for tools.massive_raw_files."""
 
+import email
+import json
+
 import tools.massive_raw_files as mrf
 from tools.massive_raw_files import (
     MassiveResolution,
@@ -101,3 +104,35 @@ def test_enrich_from_massive_proxi_survives_lookup_failure(monkeypatch):
         MassiveResolution(input_accession="MSV1", massive_accession="MSV1")
     )
     assert r.proxi_ftp_url is None  # degrades to the guessed candidates
+
+
+class _FakeHTTPResponse:
+    """Minimal stand-in for the urllib.request.urlopen() context manager."""
+
+    def __init__(self, data: bytes, charset: str):
+        self._data = data
+        self.headers = email.message_from_string(
+            f"Content-Type: application/json; charset={charset}\n"
+        )
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def test_fetch_json_decodes_declared_iso_8859_1_charset(monkeypatch):
+    """MassIVE serves charset=ISO-8859-1; json.loads() assumes UTF-8, so an
+    accented byte raises UnicodeDecodeError and drops the whole response
+    unless fetch_json honours the declared charset (see its docstring)."""
+    payload = json.dumps({"name": "Café"}, ensure_ascii=False).encode("iso-8859-1")
+    monkeypatch.setattr(
+        mrf.urllib.request,
+        "urlopen",
+        lambda request, timeout=None: _FakeHTTPResponse(payload, "iso-8859-1"),
+    )
+    assert mrf.fetch_json("http://example.org/dataset") == {"name": "Café"}

--- a/tests/test_massive_raw_files.py
+++ b/tests/test_massive_raw_files.py
@@ -1,5 +1,6 @@
 """Tests for tools.massive_raw_files."""
 
+import tools.massive_raw_files as mrf
 from tools.massive_raw_files import (
     MassiveResolution,
     file_matches_mode,
@@ -52,3 +53,51 @@ def test_file_matches_mode_for_raw_and_acquisition():
     assert not file_matches_mode("/foo/bar/sample.mzML", "raw")
     assert file_matches_mode("/foo/bar/sample.mzML", "acquisition")
     assert file_matches_mode("/foo/bar/sample.anything", "all")
+
+
+def test_ftp_candidates_prefer_massive_proxi_root():
+    """MassIVE's own root wins: ProteomeCentral omits the version directory."""
+    resolution = MassiveResolution(
+        input_accession="PXD003626",
+        massive_accession="MSV000079512",
+        ftp_url="ftp://massive.ucsd.edu/MSV000079512",           # ProteomeCentral, no /v01/
+        proxi_ftp_url="ftp://massive.ucsd.edu/v01/MSV000079512/",  # MassIVE, authoritative
+    )
+    candidates = ftp_candidates(resolution)
+    assert candidates[0] == "ftp://massive.ucsd.edu/v01/MSV000079512/"
+    assert "ftp://massive.ucsd.edu/MSV000079512" in candidates
+
+
+def test_ftp_candidates_include_v01_fallback():
+    """Older datasets (e.g. MSV000078958) live under /v01/, not /v02/."""
+    resolution = MassiveResolution(
+        input_accession="MSV000078958", massive_accession="MSV000078958"
+    )
+    assert "ftp://massive.ucsd.edu/v01/MSV000078958/" in ftp_candidates(resolution)
+
+
+def test_enrich_from_massive_proxi_reads_dataset_ftp_location(monkeypatch):
+    payload = {
+        "title": "Integrated metagenomics/metaproteomics",
+        "datasetLink": [
+            {"accession": "MS:1002488", "value": "https://massive.ucsd.edu/ProteoSAFe/QueryMSV?id=MSV000078958"},
+            {"accession": "MS:1002852", "value": "ftp://massive.ucsd.edu/v01/MSV000078958"},
+        ],
+    }
+    monkeypatch.setattr(mrf, "fetch_json", lambda url: payload)
+    r = mrf.enrich_from_massive_proxi(
+        MassiveResolution(input_accession="MSV000078958", massive_accession="MSV000078958")
+    )
+    assert r.proxi_ftp_url == "ftp://massive.ucsd.edu/v01/MSV000078958/"  # slash normalised
+    assert r.title == "Integrated metagenomics/metaproteomics"
+
+
+def test_enrich_from_massive_proxi_survives_lookup_failure(monkeypatch):
+    def boom(url):
+        raise OSError("network down")
+
+    monkeypatch.setattr(mrf, "fetch_json", boom)
+    r = mrf.enrich_from_massive_proxi(
+        MassiveResolution(input_accession="MSV1", massive_accession="MSV1")
+    )
+    assert r.proxi_ftp_url is None  # degrades to the guessed candidates

--- a/tests/test_mcp_pride.py
+++ b/tests/test_mcp_pride.py
@@ -229,6 +229,23 @@ def test_search_dedups_massive_record_already_seen_in_pride(monkeypatch):
     assert r["count"] == 1 and r["results"][0]["repository"] == "PRIDE"
 
 
+def test_search_dedups_two_massive_records_sharing_an_accession(monkeypatch):
+    """Two MassIVE hits in the same page can share an accession (e.g. a
+    dataset re-listed under both its MSV and PXD entry) — `seen` must grow as
+    each MassIVE hit is accepted, not just start from the PRIDE results."""
+    dupe = {
+        "title": "Same dataset, second listing",
+        "accession": [{"accession": "MS:1002487", "value": "MSV000079512"}],
+    }
+
+    def fake_get(url, params=None, **kw):
+        return [] if "pride" in url else [_MASSIVE, dupe]
+
+    monkeypatch.setattr(server, "_cached_get_json", fake_get)
+    r = server.search_projects("x", repository="all")
+    assert r["count"] == 1
+
+
 # --- transport-level contracts -----------------------------------------
 
 class _Resp:

--- a/tests/test_mcp_pride.py
+++ b/tests/test_mcp_pride.py
@@ -1,0 +1,268 @@
+"""Contract tests for mcp/server.py PRIDE + article-identifier tools.
+
+Offline: PRIDE responses are stubbed. These pin the exact call formats that
+skills/sdrf-metascreen/SKILL.md documents — the failure mode they guard is
+silent, because a rejected identifier degrades to "no evidence" rather than
+raising, which a screening skill then reports as `uncertain`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp"))
+import server  # noqa: E402
+
+
+# --- identifier formats -------------------------------------------------
+
+@pytest.mark.parametrize("raw", ["35695565", "PMC9174028", "10.1038/s41467-022-30310-x"])
+def test_classify_article_id_accepts_bare_forms(raw):
+    assert server._classify_article_id(raw) is not None
+
+
+@pytest.mark.parametrize("raw", ["PMID:35695565", "pmid:35695565", "doi:10.1038/x"])
+def test_classify_article_id_rejects_prefixed_forms(raw):
+    """get_article_metadata takes BARE ids. Prefixed forms yield an error record."""
+    assert server._classify_article_id(raw) is None
+
+
+def test_get_article_metadata_flags_unrecognised_instead_of_raising():
+    [rec] = server.get_article_metadata(["PMID:35695565"])
+    assert "Unrecognised identifier" in rec["error"]
+
+
+@pytest.mark.parametrize("raw", ["10.1038/s41467-022-30310-x", "https://doi.org/10.1038/x-y", "35695565"])
+def test_parse_identifier_accepts_unpaywall_forms(raw):
+    assert server._parse_identifier(raw) is not None
+
+
+def test_parse_identifier_rejects_doi_prefix():
+    """get_pdf_by_unpaywall takes a BARE DOI; the 'doi:' prefix fails the regex."""
+    assert server._parse_identifier("doi:10.1038/s41467-022-30310-x") is None
+
+
+# --- PRIDE project details ---------------------------------------------
+
+_DETAILS = {
+    "accession": "PXD005969",
+    "title": "t",
+    "projectDescription": "d",
+    "sampleProcessingProtocol": "spp",
+    "dataProcessingProtocol": "dpp",
+    "organisms": [{"name": "Human gut metagenome"}],
+    "organismParts": [{"name": "Blood"}],
+    "countries": ["Canada"],
+    "instruments": [{"name": "Q Exactive"}],
+    "experimentTypes": [{"name": "Shotgun proteomics"}],
+    "quantificationMethods": [{"name": "TIC"}],
+    "identifiedPTMStrings": [],
+    "keywords": ["Metaproteomics"],
+    "references": [],
+}
+
+
+def test_get_project_details_surfaces_screening_fields(monkeypatch):
+    """experiment_types / quantification_methods drive criteria screening."""
+    monkeypatch.setattr(server, "_cached_get_json", lambda *a, **k: _DETAILS)
+    d = server.get_project_details("PXD005969")
+    assert d["experiment_types"] == ["Shotgun proteomics"]
+    assert d["quantification_methods"] == ["TIC"]
+    assert d["organism_parts"] == ["Blood"]
+    assert d["countries"] == ["Canada"]
+    assert d["instruments"] == ["Q Exactive"]
+
+
+def test_get_project_details_reports_missing_project(monkeypatch):
+    """MassIVE accessions are not served by PRIDE — must surface, not fabricate."""
+    monkeypatch.setattr(server, "_cached_get_json", lambda *a, **k: None)
+    d = server.get_project_details("MSV000078958")
+    assert "error" in d and "not found" in d["error"]
+
+
+# --- PRIDE search -------------------------------------------------------
+
+def test_search_projects_parses_plain_string_fields(monkeypatch):
+    """/search/projects returns bare strings where /projects/{acc} returns CvParams."""
+    hit = {
+        "accession": "PXD077488",
+        "title": "t",
+        "projectDescription": "d",
+        "organisms": ["Candidatus accumulibacter phosphatis"],
+        "organismsPart": [],
+        "instruments": ["Q Exactive Plus"],
+        "experimentTypes": ["Data-dependent acquisition", "Bottom-up proteomics"],
+        "quantificationMethods": [],
+        "keywords": ["Metaproteomics"],
+        "publicationDate": "2025-01-01",
+        "sdrf": None,
+    }
+    monkeypatch.setattr(server, "_cached_get_json", lambda *a, **k: [hit])
+    r = server.search_projects("metaproteomics", repository="pride")
+    [got] = r["results"]
+    assert got["instruments"] == ["Q Exactive Plus"]
+    assert got["experiment_types"] == ["Data-dependent acquisition", "Bottom-up proteomics"]
+    assert got["organism"] == ["Candidatus accumulibacter phosphatis"]
+    assert got["has_sdrf"] is False
+
+
+def test_search_projects_parses_cvparam_fields(monkeypatch):
+    """Accept the dict shape too, so the tool survives an API alignment."""
+    hit = {"accession": "PXD1", "instruments": [{"name": "Orbitrap Eclipse"}]}
+    monkeypatch.setattr(server, "_cached_get_json", lambda *a, **k: [hit])
+    [got] = server.search_projects("x", repository="pride")["results"]
+    assert got["instruments"] == ["Orbitrap Eclipse"]
+
+
+def test_search_projects_handles_unreachable(monkeypatch):
+    monkeypatch.setattr(server, "_cached_get_json", lambda *a, **k: None)
+    r = server.search_projects("x", repository="pride")
+    assert r["count"] == 0 and r["results"] == []
+    assert any("PRIDE" in e for e in r["errors"])
+
+
+def test_search_projects_rejects_bad_repository():
+    assert "error" in server.search_projects("x", repository="nope")
+
+
+# --- MassIVE / PROXI ----------------------------------------------------
+
+_MASSIVE = {
+    "title": "Integrated metagenomics/metaproteomics",
+    "summary": "Human gut metaproteome.",
+    "accession": [
+        {"accession": "MS:1002487", "value": "MSV000079512"},
+        {"accession": "MS:1001919", "value": "PXD003626"},
+    ],
+    "instruments": [{"name": "instrument model", "value": "LTQ Orbitrap"}],
+    # species / publications / contacts are nested one list deeper than PRIDE
+    "species": [[{"name": "taxonomy: common name", "value": "Human gut metaproteome"}]],
+    "keywords": [
+        {"value": "metaproteomics"},
+        {"value": "null"},      # MassIVE writes the STRING "null" for missing
+        {"value": None},
+    ],
+    "publications": [[
+        {"accession": "MS:1000879", "value": "23209564"},
+        {"accession": "MS:1002866", "value": "Erickson AR et al. PLoS ONE. 2012."},
+    ]],
+    "modifications": [{"value": "N/A"}],
+}
+
+
+def test_proxi_values_flattens_and_drops_placeholders():
+    """The literal string 'null' is MassIVE's missing marker — never a value."""
+    assert server._proxi_values(_MASSIVE, "keywords") == ["metaproteomics"]
+    assert server._proxi_values(_MASSIVE, "species") == ["Human gut metaproteome"]
+    assert server._proxi_values(_MASSIVE, "modifications") == []
+
+
+def test_massive_to_project_prefers_pxd_and_keeps_both(monkeypatch):
+    monkeypatch.setattr(server, "_resolve_publication",
+                        lambda pmid, doi, ref: {"pmid": pmid, "pmcid": None, "doi": doi,
+                                                "is_open_access": False, "reference": ref})
+    p = server._massive_to_project(_MASSIVE)
+    assert p["accession"] == "PXD003626"
+    assert set(p["all_accessions"]) == {"MSV000079512", "PXD003626"}
+    assert p["repository"] == "MassIVE"
+    assert p["instruments"] == ["LTQ Orbitrap"]
+    assert p["publications"][0]["pmid"] == "23209564"
+    # MassIVE publishes none of these — empty, never fabricated
+    assert p["experiment_types"] == [] and p["quantification_methods"] == []
+    assert p["sample_processing_protocol"] is None
+
+
+def test_massive_search_hit_never_resolves_publications(monkeypatch):
+    """Search hits don't expose `publications` — resolving them would be a
+    wasted Europe PMC call per record. Fail loudly if that call ever fires."""
+    def boom(*a, **k):
+        raise AssertionError("search hit must not resolve publications")
+
+    monkeypatch.setattr(server, "_resolve_publication", boom)
+    hit = server._massive_search_hit(_MASSIVE)
+    assert "publications" not in hit
+    assert hit["accession"] == "PXD003626"
+    assert hit["instruments"] == ["LTQ Orbitrap"]
+
+
+def test_get_project_details_routes_msv_to_massive(monkeypatch):
+    monkeypatch.setattr(server, "_massive_get_dataset", lambda acc: _MASSIVE)
+    monkeypatch.setattr(server, "_resolve_publication",
+                        lambda *a: {"pmid": "1", "pmcid": None, "doi": None,
+                                    "is_open_access": False, "reference": ""})
+    d = server.get_project_details("MSV000079512")
+    assert d["repository"] == "MassIVE"
+    assert d["accession"] == "MSV000079512"  # echoes what was queried
+
+
+def test_get_project_details_falls_back_to_massive_for_pxd(monkeypatch):
+    """PXD003626 is real, is 404 in PRIDE, and lives at MassIVE."""
+    monkeypatch.setattr(server, "_cached_get_json", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_massive_get_dataset", lambda acc: _MASSIVE)
+    monkeypatch.setattr(server, "_resolve_publication",
+                        lambda *a: {"pmid": "1", "pmcid": None, "doi": None,
+                                    "is_open_access": False, "reference": ""})
+    d = server.get_project_details("PXD003626")
+    assert d["repository"] == "MassIVE" and "error" not in d
+
+
+def test_get_project_details_errors_when_neither_repo_has_it(monkeypatch):
+    monkeypatch.setattr(server, "_cached_get_json", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_massive_get_dataset", lambda acc: None)
+    d = server.get_project_details("PXD999999999")
+    assert "PRIDE or MassIVE" in d["error"]
+
+
+def test_search_dedups_massive_record_already_seen_in_pride(monkeypatch):
+    """A MassIVE record whose PXD is already a PRIDE hit must not double-count."""
+    pride_hit = {"accession": "PXD003626", "instruments": ["Q Exactive"]}
+
+    def fake_get(url, params=None, **kw):
+        return [pride_hit] if "pride" in url else [_MASSIVE]
+
+    monkeypatch.setattr(server, "_cached_get_json", fake_get)
+    r = server.search_projects("x", repository="all")
+    assert r["count"] == 1 and r["results"][0]["repository"] == "PRIDE"
+
+
+# --- transport-level contracts -----------------------------------------
+
+class _Resp:
+    def __init__(self, status, body: bytes, encoding="utf-8"):
+        self.status_code, self._body, self.encoding = status, body, encoding
+
+    def json(self):
+        return json.loads(self._body.decode("utf-8"))  # httpx decodes bytes as UTF-8
+
+    @property
+    def text(self):
+        return self._body.decode(self.encoding)
+
+
+def _stub_client(monkeypatch, resp):
+    server._json_cache.clear()
+    monkeypatch.setattr(server, "_get_client",
+                        lambda: type("C", (), {"get": lambda *a, **k: resp})())
+
+
+def test_cached_get_json_decodes_latin1_body(monkeypatch):
+    """MassIVE serves charset=ISO-8859-1; one accented byte must not drop a page."""
+    body = '[{"title":"Café proteomics"}]'.encode("latin-1")
+    _stub_client(monkeypatch, _Resp(200, body, encoding="ISO-8859-1"))
+    data = _cached_uncached()
+    assert data == [{"title": "Café proteomics"}]
+
+
+def _cached_uncached():
+    return server._cached_get_json("https://example.invalid/x")
+
+
+def test_cached_get_json_404_is_not_found_not_failure(monkeypatch):
+    _stub_client(monkeypatch, _Resp(404, b""))
+    assert server._cached_get_json("https://example.invalid/y") is None
+    server._json_cache.clear()
+    assert server._cached_get_json("https://example.invalid/y", not_found_ok=True) == []

--- a/tools/massive_raw_files.py
+++ b/tools/massive_raw_files.py
@@ -31,6 +31,9 @@ PX_PROXI_TEMPLATE = "https://proteomecentral.proteomexchange.org/api/proxi/v0.1/
 MASSIVE_DETAIL_TEMPLATE = (
     "https://massive.ucsd.edu/ProteoSAFe/MassiveServlet?task={task}&function=massiveinformation"
 )
+MASSIVE_PROXI_TEMPLATE = "https://massive.ucsd.edu/ProteoSAFe/proxi/v0.1/datasets/{accession}"
+# "Dataset FTP location" in the PROXI datasetLink block.
+MS_DATASET_FTP = "MS:1002852"
 
 PXD_RE = re.compile(r"^PXD\d{6,}$", re.IGNORECASE)
 MSV_RE = re.compile(r"^MSV\d+(?:\.\d+)?$", re.IGNORECASE)
@@ -61,6 +64,8 @@ class MassiveResolution:
     massive_accession: str | None = None
     task: str | None = None
     ftp_url: str | None = None
+    # MassIVE's own PROXI root — authoritative, tried before ftp_url.
+    proxi_ftp_url: str | None = None
     title: str | None = None
     hosting_repository: str | None = None
     filecount_hint: int | None = None
@@ -73,7 +78,16 @@ def fetch_json(url: str) -> object:
         headers={"Accept": "application/json", "User-Agent": USER_AGENT},
     )
     with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT) as response:
-        return json.load(response)
+        raw = response.read()
+        # MassIVE serves `application/json;charset=ISO-8859-1`. json.loads assumes
+        # UTF-8, so one accented byte (author names, European affiliations) raises
+        # UnicodeDecodeError and loses the whole response. Honour the declared
+        # charset instead of guessing.
+        charset = response.headers.get_content_charset() or "utf-8"
+        try:
+            return json.loads(raw.decode(charset))
+        except (UnicodeDecodeError, LookupError):
+            return json.loads(raw.decode("utf-8", errors="replace"))
 
 
 def normalize_accession(value: str) -> str:
@@ -168,15 +182,53 @@ def enrich_from_massive_detail(resolution: MassiveResolution) -> MassiveResoluti
     return resolution
 
 
+def enrich_from_massive_proxi(resolution: MassiveResolution) -> MassiveResolution:
+    """Record MassIVE's own FTP root for the dataset, from its PROXI record.
+
+    MassIVE is authoritative about its own layout, and the other two sources are
+    not: a bare MSV accession yields no ftp_url at all (so ftp_candidates() could
+    only guess `/v02/`, while e.g. MSV000078958 lives under `/v01/`), and the
+    ProteomeCentral route yields a root with the version directory missing
+    (`ftp://massive.ucsd.edu/MSV000079512` vs the real
+    `ftp://massive.ucsd.edu/v01/MSV000079512`). Both fail the FTP walk. Ask
+    MassIVE instead of guessing, and try this root first.
+    """
+    if not resolution.massive_accession:
+        return resolution
+    try:
+        payload = fetch_json(
+            MASSIVE_PROXI_TEMPLATE.format(
+                accession=urllib.parse.quote(resolution.massive_accession)
+            )
+        )
+    except Exception:
+        return resolution
+    if not isinstance(payload, dict):
+        return resolution
+
+    for link in payload.get("datasetLink", []) or []:
+        if not isinstance(link, dict):
+            continue
+        value = str(link.get("value") or "").strip()
+        if link.get("accession") == MS_DATASET_FTP and value.startswith("ftp://"):
+            resolution.proxi_ftp_url = value if value.endswith("/") else value + "/"
+            break
+    if not resolution.title and payload.get("title"):
+        resolution.title = str(payload["title"])
+    return resolution
+
+
 def ftp_candidates(resolution: MassiveResolution) -> list[str]:
     candidates: list[str] = []
-    if resolution.ftp_url:
-        candidates.append(resolution.ftp_url)
+    for url in (resolution.proxi_ftp_url, resolution.ftp_url):
+        if url and url not in candidates:
+            candidates.append(url)
     if resolution.massive_accession:
         msv = resolution.massive_accession
         for url in (
             f"ftp://massive-ftp.ucsd.edu/v02/{msv}/",
             f"ftp://massive.ucsd.edu/v02/{msv}/",
+            f"ftp://massive.ucsd.edu/v01/{msv}/",
             f"ftp://massive.ucsd.edu/{msv}/",
         ):
             if url not in candidates:
@@ -280,12 +332,16 @@ def resolve_accession(accession: str) -> MassiveResolution:
     accession = normalize_accession(accession)
     if PXD_RE.match(accession):
         resolution = resolve_from_proteomecentral(accession.upper())
-        return enrich_from_massive_detail(resolution)
+        return enrich_from_massive_proxi(enrich_from_massive_detail(resolution))
     if MSV_RE.match(accession):
-        return MassiveResolution(input_accession=accession.upper(), massive_accession=accession.upper())
+        return enrich_from_massive_proxi(
+            MassiveResolution(
+                input_accession=accession.upper(), massive_accession=accession.upper()
+            )
+        )
     if TASK_RE.match(accession):
         resolution = MassiveResolution(input_accession=accession.lower(), task=accession.lower())
-        return enrich_from_massive_detail(resolution)
+        return enrich_from_massive_proxi(enrich_from_massive_detail(resolution))
     raise SystemExit(f"Unsupported accession format: {accession}")
 
 

--- a/tools/massive_raw_files.py
+++ b/tools/massive_raw_files.py
@@ -415,7 +415,7 @@ def run_cli(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     resolution = resolve_accession(args.accession)
     if args.summary_only:
-        emit_json(resolution, resolution.ftp_url, [])
+        emit_json(resolution, resolution.proxi_ftp_url or resolution.ftp_url, [])
         return 0
 
     candidates = [args.ftp_url] if args.ftp_url else ftp_candidates(resolution)


### PR DESCRIPTION
Both tools now span PRIDE and MassIVE (PROXI API): MSV… routes straight to MassIVE, PXD… tries PRIDE then falls back to MassIVE for ProteomeXchange datasets PRIDE never held (e.g. PXD003626). Handles PROXI's parsing traps (value vs name, nested lists, literal "null") and its ISO-8859-1 charset, which was silently dropping result pages on accented characters.

sdrf-metascreen now screens both repositories by default, records a repository column, dedupes on all_accessions, and documents that MassIVE's structured pre-filter fields are mostly empty (measured: instruments 100% PRIDE vs 3% MassIVE) so most MassIVE candidates get decided from the publication rather than excluded for thin metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-repository project search across PRIDE and MassIVE, with deduplicated accessions and richer project details.
  * Added MassIVE PROXI metadata support, improved FTP discovery, and fallback handling.
  * Expanded SDRF metadata screening with resumable TSV output, repository-aware filtering, progress logs, and criterion-level reporting.

* **Bug Fixes**
  * Improved handling of alternate character encodings, missing resources, paging responses, and publication identifiers.

* **Documentation**
  * Updated tool inventory, MassIVE guidance, project routing details, and screening output documentation.

* **Tests**
  * Added coverage for MassIVE, PRIDE, PROXI, FTP fallback, identifier parsing, and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->