### PR TITLE
Align acquisition-method guidance with the PRIDE:0000659 policy

### DIFF
--- a/skills/sdrf-fix/SKILL.md
+++ b/skills/sdrf-fix/SKILL.md
@@ -72,12 +72,12 @@ Verify that `parse_sdrf` is available (run `parse_sdrf --version` or `which pars
 ### 6. DIA/DDA Terminology
 | Wrong | Correct |
 |-------|---------|
-| `data-dependent acquisition` | `Data-Dependent Acquisition` |
-| `data-independent` | `Data-Independent Acquisition` |
-| `DDA` | `Data-Dependent Acquisition` |
-| `DIA` | `Data-Independent Acquisition` |
+| `data-dependent acquisition` / `DDA` | `NT=Data-dependent acquisition;AC=PRIDE:0000627` |
+| `data-independent acquisition` / `DIA` | `NT=Data-independent acquisition;AC=PRIDE:0000450` |
+| `PRM` | `NT=Parallel reaction monitoring;AC=PRIDE:0000629` |
+| `SRM` / `MRM` | `NT=Selected reaction monitoring;AC=PRIDE:0000630` |
 
-**Fix**: Use the ontology-standard full name.
+**Fix**: Use `NT=<OLS label>;AC=<accession>` — the OLS label written as-is (e.g. `Data-dependent acquisition`, sentence case, not Title Case) with its accession, a descendant of `PRIDE:0000659`. DIA variants (diaPASEF, SWATH) map to `PRIDE:0000450`.
 
 ### 7. Age Format
 | Wrong | Correct |

--- a/skills/sdrf-knowledge/SKILL.md
+++ b/skills/sdrf-knowledge/SKILL.md
@@ -137,7 +137,7 @@ Rows = samples × fractions × label_channels × technical_replicates
 2. **Missing ontology prefix** — "0000305" instead of "EFO:0000305"
 3. **Case mismatch** — "Male" instead of "male" (SDRF values are lowercase)
 4. **Python artifacts** — "['value']" instead of "value"
-5. **DIA mislabeling** — Use "Data-Independent Acquisition" (PRIDE ontology term)
+5. **DIA mislabeling** — Use `NT=Data-independent acquisition;AC=PRIDE:0000450` (OLS label as written + accession under PRIDE:0000659)
 6. **Wrong reserved word** — "N/A", "NA", "unknown" instead of "not available"
 7. **Age format** — "58 years" instead of "58Y"
 8. **Missing AC= in instruments** — Just "Q Exactive" without `AC=MS:1001911;NT=Q Exactive`

--- a/skills/sdrf-techrefine/SKILL.md
+++ b/skills/sdrf-techrefine/SKILL.md
@@ -135,7 +135,7 @@ has generic names (e.g., "Q Exactive") while raw files have the specific model
 ### 5.2 Acquisition mode
 | Detected Field | Method | Example |
 |---------------|--------|---------|
-| DDA vs DIA | Spectrum analysis | Data-Dependent Acquisition |
+| DDA vs DIA | Spectrum analysis | `NT=Data-dependent acquisition;AC=PRIDE:0000627` |
 
 **What to check**: Is the acquisition method in the SDRF correct? Misclassification
 of DDA as DIA (or vice versa) affects which analysis pipelines can be used.

--- a/tools/sdrf_fixer.py
+++ b/tools/sdrf_fixer.py
@@ -84,13 +84,21 @@ _AGE_UNIT_MAP = {
 
 _PYTHON_ARTIFACT_RE = re.compile(r"^\[?['\"](.+?)['\"]\]?$")
 
+# Acquisition method must be a descendant of PRIDE:0000659, encoded as the OLS label
+# written as-is plus its accession (NT=<OLS label>;AC=PRIDE:...). See the SDRF spec's
+# proteomics-data-acquisition-method policy.
 _DDA_DIA_FIXES = {
-    "data-dependent acquisition": "Data-Dependent Acquisition",
-    "data-independent acquisition": "Data-Independent Acquisition",
-    "data-independent": "Data-Independent Acquisition",
-    "data-dependent": "Data-Dependent Acquisition",
-    "dda": "Data-Dependent Acquisition",
-    "dia": "Data-Independent Acquisition",
+    "data-dependent acquisition": "NT=Data-dependent acquisition;AC=PRIDE:0000627",
+    "data-independent acquisition": "NT=Data-independent acquisition;AC=PRIDE:0000450",
+    "data-independent": "NT=Data-independent acquisition;AC=PRIDE:0000450",
+    "data-dependent": "NT=Data-dependent acquisition;AC=PRIDE:0000627",
+    "dda": "NT=Data-dependent acquisition;AC=PRIDE:0000627",
+    "dia": "NT=Data-independent acquisition;AC=PRIDE:0000450",
+    "prm": "NT=Parallel reaction monitoring;AC=PRIDE:0000629",
+    "parallel reaction monitoring": "NT=Parallel reaction monitoring;AC=PRIDE:0000629",
+    "srm": "NT=Selected reaction monitoring;AC=PRIDE:0000630",
+    "mrm": "NT=Selected reaction monitoring;AC=PRIDE:0000630",
+    "selected reaction monitoring": "NT=Selected reaction monitoring;AC=PRIDE:0000630",
 }
 
 
@@ -192,7 +200,7 @@ def _fix_dda_dia(value: str) -> tuple[str | None, str]:
     """Fix DDA/DIA terminology."""
     fixed = _DDA_DIA_FIXES.get(value.lower())
     if fixed and fixed != value:
-        return fixed, f"Standardized acquisition method to ontology term"
+        return fixed, "Standardized acquisition method to PRIDE NT+AC form (under PRIDE:0000659)"
     return None, ""
 
 


### PR DESCRIPTION
The SDRF spec and templates now standardize `comment[proteomics data acquisition method]` as a **descendant of PRIDE:0000659**, encoded as the **OLS label written as-is + its accession** (`NT=<OLS label>;AC=PRIDE:...`), and `comment[dia method]` was removed from the templates so DIA variants (diaPASEF, SWATH) live in the acquisition column under `PRIDE:0000450`.

Several places here still normalized to **Title-Case plain labels** (`Data-Dependent Acquisition`) with no accession — which conflicts with that policy and with the `sdrf-annotate` skill (§5.5), which is already on the NT+AC form.

Updated to match:
- `tools/sdrf_fixer.py` — `_DDA_DIA_FIXES` now maps to `NT=Data-dependent acquisition;AC=PRIDE:0000627`, DIA `PRIDE:0000450`, PRM `PRIDE:0000629`, SRM/MRM `PRIDE:0000630` (verified the fixer emits these).
- `skills/sdrf-fix`, `skills/sdrf-knowledge`, `skills/sdrf-techrefine` — same NT+AC guidance, noting the OLS label is sentence-case (`Data-dependent acquisition`), not Title Case.

No test pinned the old output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Acquisition methods are now normalized using standardized ontology labels and PRIDE accessions.
  - Supports DDA, DIA, PRM, SRM, and MRM terminology, including variants such as diaPASEF and SWATH.
  - Generated SDRF values now use the consistent `NT=<label>;AC=<accession>` format.

- **Documentation**
  - Updated guidance and examples to reflect the standardized acquisition-method values and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->