### PR TITLE
fix(skills): correct three wrong XLMOD cross-linker accessions

### DIFF
--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -556,10 +556,25 @@ Crosslinking cleanup examples that should be normalized before final validation:
 - `deinococcus radiodurans r1` → `deinococcus radiodurans`
 
 For crosslinking-specific assay cleanup, use explicit file-name evidence when the SDRF still says `NT=unknown crosslinker;AC=XLMOD:00000`. Safe examples seen in sandbox cleanup:
-- file names containing `DSSO` → `NT=DSSO;AC=XLMOD:02010;CL=yes;TA=K,S,T,Y,nterm;MH=54.01;ML=85.98`
+- file names containing `DSSO` → `NT=DSSO;AC=XLMOD:02126;CL=yes;TA=K,S,T,Y,nterm;MH=54.01;ML=85.98`
+- file names containing `DSS` → `NT=DSS;AC=XLMOD:02001`
 - file names containing `BS3` → `NT=BS3;AC=XLMOD:02000`
-- file names containing `TurboID` → `NT=TurboID;AC=XLMOD:02251`
-- file names containing `iQPIR`, `BDP`, or `d8BDP` → `NT=PIR;AC=XLMOD:02014`
+- file names containing `DSBU` → `NT=DSBU;AC=XLMOD:02120` (XLMOD's preferred label is `BuUrBu`)
+- file names containing `iQPIR`, `BDP`, or `d8BDP` → `NT=PIR;AC=XLMOD:02237`
+  (the BDP-NHP reagent itself is `XLMOD:02011`)
+
+> **Verify every XLMOD accession against OLS before writing it.** Neighbouring
+> XLMOD ids are unrelated reagents, so a wrong accession is validator-clean and
+> silently corrupts the annotation. Confirm with:
+> `curl -s "https://www.ebi.ac.uk/ols4/api/search?q=XLMOD:02126&ontology=xlmod&fieldList=obo_id,label"`
+
+**`TurboID` is not a cross-linker — do not map it to `comment[cross-linker]`.**
+It is a promiscuous biotin ligase used for proximity-dependent labelling
+(BioID family), not a chemical cross-linking reagent, and XLMOD has no term for
+it. Proximity-labelling experiments are not XL-MS: annotate the biotin
+enrichment via `characteristics[enrichment process]` /
+`comment[crosslink enrichment method]` and do not apply the `crosslinking`
+template on the strength of a `TurboID` filename token alone.
 
 After recovering a known cross-linker, backfill `characteristics[crosslink distance]` when the template guidance is explicit:
 - `BS3` / `DSS` → `30 Å`

--- a/skills/sdrf-validate/SKILL.md
+++ b/skills/sdrf-validate/SKILL.md
@@ -156,10 +156,21 @@ crosslinking datasets:
 - `deinococcus radiodurans r1` → `deinococcus radiodurans`
 
 If a crosslinking SDRF still uses `NT=unknown crosslinker;AC=XLMOD:00000`, inspect `comment[data file]` for explicit reagent tokens before accepting the placeholder. Examples validated in sandbox cleanup:
-- `DSSO` in file name → `NT=DSSO;AC=XLMOD:02010;CL=yes;TA=K,S,T,Y,nterm;MH=54.01;ML=85.98`
+- `DSSO` in file name → `NT=DSSO;AC=XLMOD:02126;CL=yes;TA=K,S,T,Y,nterm;MH=54.01;ML=85.98`
+- `DSS` in file name → `NT=DSS;AC=XLMOD:02001`
 - `BS3` in file name → `NT=BS3;AC=XLMOD:02000`
-- `TurboID` in file name → `NT=TurboID;AC=XLMOD:02251`
-- `iQPIR`, `BDP`, or `d8BDP` in file name → `NT=PIR;AC=XLMOD:02014`
+- `DSBU` in file name → `NT=DSBU;AC=XLMOD:02120` (XLMOD's preferred label is `BuUrBu`)
+- `iQPIR`, `BDP`, or `d8BDP` in file name → `NT=PIR;AC=XLMOD:02237`
+  (the BDP-NHP reagent itself is `XLMOD:02011`)
+
+> **Verify every XLMOD accession against OLS before accepting it.** Neighbouring
+> XLMOD ids are unrelated reagents, so a wrong accession passes validation and
+> silently corrupts the annotation.
+
+**`TurboID` is not a cross-linker.** It is a promiscuous biotin ligase used for
+proximity-dependent labelling (BioID family); XLMOD has no term for it. Flag a
+`comment[cross-linker]` value of `TurboID` as an error rather than repairing it
+to an accession.
 
 When a specific cross-linker is recovered, validate whether `characteristics[crosslink distance]` can be backfilled from the crosslinking template:
 - `BS3` / `DSS` → `30 Å`


### PR DESCRIPTION
## Problem

The cross-linker recovery tables in `skills/sdrf-annotate/SKILL.md` and
`skills/sdrf-validate/SKILL.md` map **three of their four reagents** to XLMOD
accessions belonging to unrelated chemistry.

Every wrong id is itself a real XLMOD term, so the resulting SDRF **passes
validation** and the error propagates silently into every dataset annotated
with the skill.

Verified against OLS4 (`ols4/api/search?ontology=xlmod`):

| Guidance says | That accession actually is | Correct |
|---|---|---|
| `DSSO = XLMOD:02010` | 1-ethyl-3-(3-dimethylaminopropyl)carbodiimide hydrochloride (**EDC**) | **`XLMOD:02126`** |
| `PIR = XLMOD:02014` | **EMCS** (6-maleimidohexanoic acid NHS ester) | **`XLMOD:02237`** |
| `TurboID = XLMOD:02251` | **MC4** | *no XLMOD term exists* |

`DSSO` is the most damaging: EDC is a **zero-length** cross-linker, so the
accession asserts the opposite of DSSO's 26.4 A spacer. The same file's
distance table already lists `EDC -> 11.4 A`, directly contradicting the
accession it emits for DSSO.

Reproduce:

```bash
curl -s "https://www.ebi.ac.uk/ols4/api/search?q=XLMOD:02010&ontology=xlmod&fieldList=obo_id,label"
# -> 1-ethyl-3-(3-Dimethylaminopropyl)carbodiimide hydrochloride
curl -s "https://www.ebi.ac.uk/ols4/api/search?q=DSSO&ontology=xlmod&fieldList=obo_id,label"
# -> XLMOD:02126 = DSSO
```

## Changes

- `DSSO` -> `XLMOD:02126`, `PIR` -> `XLMOD:02237` (BDP-NHP reagent noted as `XLMOD:02011`).
- **`TurboID` removed rather than remapped.** It is a promiscuous biotin ligase
  used for proximity-dependent labelling (BioID family), not a chemical
  cross-linking reagent, and XLMOD has no term for it. Mapping a `TurboID`
  filename token into `comment[cross-linker]` also drags in the `crosslinking`
  template for experiments that are not XL-MS at all.
- Added `DSS` (`XLMOD:02001`) and `DSBU` (`XLMOD:02120`, preferred label
  `BuUrBu`), which both distance tables already reference without ever giving
  an accession.
- Added a note to verify XLMOD ids against OLS before writing them, since
  neighbouring ids are unrelated reagents.

## How this surfaced

Annotating **PXD014337** (Beveridge et al., *Nat Commun* 2020 - a synthetic
crosslinked peptide library benchmarking XL-MS search engines, using DSS, DSBU
and DSSO). Following the skill verbatim would have labelled the DSSO samples
with EDC's accession.

## Not covered here

`spec/sdrf-proteomics/sdrf-templates/crosslinking/1.0.0/crosslinking.yaml`
carries the same `DSSO = XLMOD:02010` error in four places (lines 10, 21, 83),
but lives in the `bigbio/sdrf-templates` submodule and needs a separate PR
there. Happy to open it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cross-linker guidance to recognize DSS, DSBU, PIR, DSSO, and BS3 variants with corrected XLMOD accessions.
  * Added requirements to verify all XLMOD accessions against OLS and warnings about neighboring identifiers representing different reagents.
  * Clarified that TurboID is a proximity-labeling reagent, not a chemical cross-linker, and should be handled through enrichment-related fields.
  * Validation guidance now flags TurboID as invalid cross-linker input instead of automatically repairing it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->