### PR TITLE
fix(tools): stop reporting valid CV terms as hallucinated

### DIFF
--- a/tests/test_hallucination.py
+++ b/tests/test_hallucination.py
@@ -222,3 +222,111 @@ class TestDetectHallucinationsOnline:
         )
         assert len(report.verified) == 1
         assert report.verified[0].label == "HeLa S3"
+
+
+class TestStructuredCVColumns:
+    """comment[...] CV columns are written NT=<label>;AC=<accession>.
+
+    Regression tests: these columns were routed to the bare-label checker,
+    which searched OLS for the literal cell string and always missed, so every
+    value was reported as hallucinated.
+    """
+
+    @staticmethod
+    def _client():
+        client = MagicMock(spec=OLSClient)
+        client.verify_accession.return_value = VerificationResult(
+            accession="MS:1002038",
+            expected_label="label free sample",
+            exists=True,
+            resolved_term=OLSTerm(
+                iri="http://purl.obolibrary.org/obo/MS_1002038",
+                label="label free sample",
+                short_form="MS:1002038",
+                ontology_name="ms",
+            ),
+            label_match=True,
+        )
+        return client
+
+    def test_label_column_not_hallucinated(self):
+        client = self._client()
+        sdrf = (
+            "source name\tcomment[label]\n"
+            "s1\tNT=label free sample;AC=MS:1002038\n"
+        )
+        report = detect_hallucinations(sdrf, ols_client=client, verify_online=True)
+        assert report.hallucinated == []
+        assert len(report.verified) == 1
+        assert report.verified[0].accession == "MS:1002038"
+
+    def test_dissociation_method_not_hallucinated(self):
+        client = self._client()
+        client.verify_accession.return_value = VerificationResult(
+            accession="MS:1000133",
+            expected_label="collision-induced dissociation",
+            exists=True,
+            resolved_term=OLSTerm(
+                iri="http://purl.obolibrary.org/obo/MS_1000133",
+                label="collision-induced dissociation",
+                short_form="MS:1000133",
+                ontology_name="ms",
+            ),
+            label_match=True,
+        )
+        sdrf = (
+            "source name\tcomment[dissociation method]\n"
+            "s1\tNT=collision-induced dissociation;AC=MS:1000133\n"
+        )
+        report = detect_hallucinations(sdrf, ols_client=client, verify_online=True)
+        assert report.hallucinated == []
+        assert len(report.verified) == 1
+
+    def test_structured_value_in_unmapped_column_is_checked(self):
+        """A column outside COLUMN_ONTOLOGY_MAP still gets verified when its
+        values carry AC= — e.g. comment[cross-linker] (XLMOD)."""
+        client = MagicMock(spec=OLSClient)
+        client.verify_accession.return_value = VerificationResult(
+            accession="XLMOD:02126",
+            expected_label="DSSO",
+            exists=True,
+            resolved_term=OLSTerm(
+                iri="http://purl.obolibrary.org/obo/XLMOD_02126",
+                label="DSSO",
+                short_form="XLMOD:02126",
+                ontology_name="xlmod",
+            ),
+            label_match=True,
+        )
+        sdrf = (
+            "source name\tcomment[cross-linker]\n"
+            "s1\tNT=DSSO;AC=XLMOD:02126\n"
+        )
+        report = detect_hallucinations(sdrf, ols_client=client, verify_online=True)
+        assert report.total_terms_checked == 1
+        assert report.hallucinated == []
+
+    def test_provenance_column_without_accession_is_skipped(self):
+        """comment[sdrf template] uses NT=..;VV=.. and carries no accession,
+        so it must not be treated as a CV column."""
+        client = MagicMock(spec=OLSClient)
+        sdrf = (
+            "source name\tcomment[sdrf template]\n"
+            "s1\tNT=ms-proteomics;VV=v1.1.0\n"
+        )
+        report = detect_hallucinations(sdrf, ols_client=client, verify_online=True)
+        assert report.total_terms_checked == 0
+        assert report.hallucinated == []
+        client.verify_accession.assert_not_called()
+
+    def test_reserved_words_do_not_decide_column_style(self):
+        """A leading 'not applicable' must not make the column look bare-label."""
+        client = self._client()
+        sdrf = (
+            "source name\tcomment[label]\n"
+            "s1\tnot applicable\n"
+            "s2\tNT=label free sample;AC=MS:1002038\n"
+        )
+        report = detect_hallucinations(sdrf, ols_client=client, verify_online=True)
+        assert report.hallucinated == []
+        assert len(report.verified) == 1

--- a/tests/test_ols_client.py
+++ b/tests/test_ols_client.py
@@ -1,0 +1,63 @@
+"""Tests for tools.ols_client payload normalisation."""
+
+from __future__ import annotations
+
+from tools.ols_client import OLSClient, _collect_synonyms, _labels_match
+
+
+class TestCollectSynonyms:
+    """OLS4 spells the synonym field three different ways.
+
+    Regression tests: only ``synonyms`` was read, so every term resolved via
+    the /search endpoint came back with an empty synonym list and any SDRF
+    using a term's common name instead of its primary label was reported as a
+    label mismatch.
+    """
+
+    def test_terms_endpoint_key(self):
+        assert _collect_synonyms({"synonyms": ["DSBU"]}) == ["DSBU"]
+
+    def test_search_default_key(self):
+        """/search without fieldList returns 'exact_synonyms'."""
+        doc = {"label": "BuUrBu", "exact_synonyms": ["DSBU", "NHS-BuUrBu-NHS"]}
+        assert _collect_synonyms(doc) == ["DSBU", "NHS-BuUrBu-NHS"]
+
+    def test_search_fieldlist_key(self):
+        """/search with fieldList=...synonym returns 'synonym'."""
+        assert _collect_synonyms({"synonym": ["DSBU"]}) == ["DSBU"]
+
+    def test_keys_are_merged_and_deduped(self):
+        doc = {"synonyms": ["DSBU"], "exact_synonyms": ["DSBU", "other"]}
+        assert _collect_synonyms(doc) == ["DSBU", "other"]
+
+    def test_missing_and_empty_are_safe(self):
+        assert _collect_synonyms({}) == []
+        assert _collect_synonyms({"synonyms": None}) == []
+        assert _collect_synonyms({"exact_synonyms": []}) == []
+
+    def test_scalar_string_is_wrapped(self):
+        assert _collect_synonyms({"synonym": "DSBU"}) == ["DSBU"]
+
+    def test_doc_to_term_populates_synonyms_from_search_payload(self):
+        """The real failure: a /search doc lost its synonyms entirely."""
+        doc = {
+            "iri": "http://purl.obolibrary.org/obo/XLMOD_02120",
+            "label": "BuUrBu",
+            "obo_id": "XLMOD:02120",
+            "ontology_name": "xlmod",
+            "exact_synonyms": ["DSBU", "Disuccinimidyl dibutyric urea"],
+        }
+        term = OLSClient._doc_to_term(doc)
+        assert "DSBU" in term.synonyms
+        # DSBU is what an SDRF author writes; BuUrBu is the primary label.
+        assert _labels_match("DSBU", term.label, term.synonyms)
+
+
+class TestAccessionToIri:
+    def test_xlmod_resolves_via_term_endpoint(self):
+        """XLMOD was absent from the IRI map, forcing the search fallback."""
+        iri = OLSClient._accession_to_iri("XLMOD:02120", "xlmod")
+        assert iri == "http://purl.obolibrary.org/obo/XLMOD_02120"
+
+    def test_unknown_ontology_returns_none(self):
+        assert OLSClient._accession_to_iri("NOPE:0001", "nope") is None

--- a/tools/hallucination.py
+++ b/tools/hallucination.py
@@ -25,6 +25,17 @@ from tools.sdrf_parser import (
 )
 
 
+# Columns whose values are ALWAYS written as NT=<label>;AC=<accession>, even
+# when a row carries a reserved word instead. Columns outside this set are
+# dispatched on their actual values by _has_structured_values().
+STRUCTURED_COLUMNS = frozenset({
+    "instrument",
+    "cleavage agent details",
+    "label",
+    "dissociation method",
+})
+
+
 # ---------------------------------------------------------------------------
 # Report dataclasses
 # ---------------------------------------------------------------------------
@@ -275,7 +286,7 @@ def detect_hallucinations(
 
         if inner == "modification parameters":
             _check_modification_column(sdrf, col_key, report)
-        elif inner in ("instrument", "cleavage agent details"):
+        elif inner in STRUCTURED_COLUMNS or _has_structured_values(sdrf, col_key):
             _check_structured_column(sdrf, col_key, inner, expected_onts,
                                      report, ols_client, verify_online)
         elif expected_onts:
@@ -283,6 +294,27 @@ def detect_hallucinations(
                                    report, ols_client, verify_online)
 
     return report
+
+
+def _has_structured_values(sdrf: SDRFFile, col_name: str) -> bool:
+    """True when this column's values carry an ``AC=`` accession.
+
+    Dispatching on the value rather than the column name matters because
+    ontology-controlled columns are written in BOTH styles across the corpus:
+    ``characteristics[...]`` conventionally hold a bare label, while
+    ``comment[...]`` CV columns hold ``NT=<label>;AC=<accession>``. Handing a
+    structured value to the bare-label checker makes it search OLS for the
+    literal string ``"NT=label free sample;AC=MS:1002038"``, which can never
+    match, and the term is then reported as hallucinated.
+
+    Only the first non-reserved value is inspected: a column mixes styles
+    only if it is already malformed, and that is reported elsewhere.
+    """
+    for row in sdrf.rows:
+        val = row.get(col_name, "").strip()
+        if val and val.lower() not in ("not available", "not applicable"):
+            return "AC=" in val
+    return False
 
 
 def _check_modification_column(

--- a/tools/ols_client.py
+++ b/tools/ols_client.py
@@ -246,19 +246,30 @@ class OLSClient:
             "chebi": f"http://purl.obolibrary.org/obo/CHEBI_{local}",
             "bto": f"http://purl.obolibrary.org/obo/BTO_{local}",
             "pride": f"http://purl.obolibrary.org/obo/PRIDE_{local}",
+            "xlmod": f"http://purl.obolibrary.org/obo/XLMOD_{local}",
         }
         return iri_bases.get(ont)
 
     @staticmethod
     def _doc_to_term(doc: dict) -> OLSTerm:
-        """Convert an OLS search result doc to OLSTerm."""
+        """Convert an OLS search result doc to OLSTerm.
+
+        See _collect_synonyms for why the synonym key cannot be assumed.
+        """
         return OLSTerm(
             iri=doc.get("iri", ""),
             label=doc.get("label", ""),
             short_form=doc.get("short_form", doc.get("obo_id", "")),
             ontology_name=doc.get("ontology_name", ""),
             description=(doc.get("description") or [""])[0] if isinstance(doc.get("description"), list) else doc.get("description", ""),
-            synonyms=doc.get("synonyms", []) or [],
+            # The /search endpoint does NOT use the key "synonyms" that the
+            # /terms endpoint uses: by default it returns "exact_synonyms", and
+            # "synonym" when that field is requested explicitly via fieldList.
+            # Reading only the plural left every search-resolved term with an
+            # empty synonym list, so an SDRF using a reagent's common name
+            # (e.g. DSBU for XLMOD:02120, whose preferred label is BuUrBu) was
+            # reported as a label mismatch.
+            synonyms=_collect_synonyms(doc),
             is_obsolete=doc.get("is_obsolete", False),
         )
 
@@ -274,7 +285,7 @@ class OLSClient:
             short_form=data.get("short_form", data.get("obo_id", "")),
             ontology_name=data.get("ontology_name", ""),
             description=desc,
-            synonyms=data.get("synonyms", []) or [],
+            synonyms=_collect_synonyms(data),
             is_obsolete=data.get("is_obsolete", False),
         )
 
@@ -282,6 +293,31 @@ class OLSClient:
 # ---------------------------------------------------------------------------
 # Label matching
 # ---------------------------------------------------------------------------
+
+def _collect_synonyms(doc: dict) -> list[str]:
+    """Gather synonyms from an OLS payload regardless of which key it used.
+
+    OLS4 spells this field three different ways depending on the endpoint and
+    on whether `fieldList` was supplied:
+
+    * ``/ontologies/{ont}/terms``     -> ``synonyms``
+    * ``/search`` (default fields)    -> ``exact_synonyms``
+    * ``/search`` with ``fieldList``  -> ``synonym``
+
+    Returns a de-duplicated list preserving first-seen order.
+    """
+    seen: dict[str, None] = {}
+    for key in ("synonyms", "synonym", "exact_synonyms"):
+        value = doc.get(key)
+        if not value:
+            continue
+        if isinstance(value, str):
+            value = [value]
+        for syn in value:
+            if syn:
+                seen.setdefault(syn, None)
+    return list(seen)
+
 
 def _labels_match(expected: str, actual: str, synonyms: list[str] | None = None) -> bool:
     """Check if an expected label matches the OLS term label or synonyms."""


### PR DESCRIPTION
## Problem

`python -m tools check` reports **every** value in `comment[label]` and
`comment[dissociation method]` as hallucinated, on any SDRF:

```
Hallucinated:
  Row(s) [1..9]: 'NT=label free sample;AC=MS:1002038' in comment[label]
  Row(s) [1..6]: 'NT=beam-type collision-induced dissociation;AC=MS:1000422' in comment[dissociation method]
```

All of these accessions are real, non-obsolete and correctly labelled —
confirmed via OLS4 and via this repo's own `python -m tools verify`. These are
false positives, and dangerous ones: an agent that trusts the checker will
"repair" a correct annotation into a wrong one.

Two independent bugs, both in the structured-value path.

### 1. Wrong checker for `NT=;AC=` columns

`detect_hallucinations()` routed only `instrument` and `cleavage agent details`
to `_check_structured_column()`. Everything else with an entry in
`COLUMN_ONTOLOGY_MAP` fell through to `_check_ontology_column()`, which treats
the cell as a **bare label** and searches OLS for the literal string
`"NT=label free sample;AC=MS:1002038"`. That can never match.

`comment[label]` and `comment[dissociation method]` are ontology-controlled but
conventionally written structured — **10,635** and **16,238** rows respectively
in `bigbio/sdrf-annotated-datasets` use the `NT=;AC=` form.

Dispatch is now driven by the **value**: a column is structured when its values
carry `AC=`. This also fixes columns absent from `COLUMN_ONTOLOGY_MAP` that
were previously skipped entirely — notably `comment[cross-linker]` (XLMOD) and
`comment[proteomics data acquisition method]` (PRIDE) — so they are now
verified instead of silently ignored. Provenance columns such as
`comment[sdrf template]` use `NT=;VV=` with no accession and remain skipped.

### 2. Synonyms dropped from search-resolved terms

OLS4 spells the synonym field three different ways:

| Endpoint | Key |
|---|---|
| `/ontologies/{ont}/terms` | `synonyms` |
| `/search` (default fields) | `exact_synonyms` |
| `/search` with `fieldList` | `synonym` |

`_doc_to_term()` read only `synonyms`, so every term resolved through the
search fallback carried an **empty** synonym list and `_labels_match()` had
nothing to match against. An SDRF using a reagent's common name was then
reported as a label mismatch — e.g. `NT=DSBU;AC=XLMOD:02120`, whose OLS primary
label is `BuUrBu` and whose registered synonyms include `DSBU`.

`_collect_synonyms()` now reads all three keys, merged and de-duplicated.

XLMOD was also missing from the IRI map in `_accession_to_iri()`, which is why
XLMOD terms took the search fallback in the first place; it is now mapped to
`http://purl.obolibrary.org/obo/XLMOD_{local}`.

## Verified on two real annotations

| | before | after |
|---|---|---|
| PXD020948 | 16 checked, **2 hallucinated** | 17 checked, 17 verified, **CLEAN** |
| PXD014337 | 9 checked, **5 hallucinated** | 16 checked, 16 verified, **CLEAN** |

## Tests

14 regression tests added (`tests/test_hallucination.py::TestStructuredCVColumns`,
new `tests/test_ols_client.py`), covering both `NT=;AC=` columns, the
unmapped-but-structured case, the provenance-column exclusion, a leading
reserved word not misclassifying a column, and all three OLS synonym keys.

Full suite: **183 passed** (169 before). `tests/test_mcp_pride.py` and
`tests/test_mcp_server.py` were skipped locally — `fastmcp` is not installed in
this environment; unrelated to this change.