### PR TITLE
fix(tools): accept a factor value backed by a comment column

### DIFF
--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -160,3 +160,43 @@ class TestToleranceColumnsNotRequired:
         assert len(recommended_issues) == 2, (
             f"Both tolerance columns should be flagged as recommended: {report.completeness.issues}"
         )
+
+
+class TestFactorValueSource:
+    """A factor value restates a variable declared elsewhere in the file.
+
+    Regression test: _score_design only scanned characteristics columns, so a
+    factor on a technical variable was always penalised. The crosslinking
+    template declares the cross-linker as comment[cross-linker], which means a
+    cross-linker factor could never satisfy the check on any XL-MS dataset.
+    """
+
+    HEADER = (
+        "source name\tcharacteristics[organism]\tcharacteristics[organism part]\t"
+        "characteristics[disease]\tcharacteristics[biological replicate]\t"
+        "assay name\ttechnology type\tcomment[cross-linker]\t"
+        "comment[fraction identifier]\tcomment[technical replicate]\t"
+        "comment[data file]\tcomment[sdrf version]\t{factor}\n"
+    )
+    ROW = (
+        "s1\tHomo sapiens\tnot applicable\tnormal\t1\trun 1\t"
+        "proteomic profiling by mass spectrometry\tNT=DSSO;AC=XLMOD:02126\t"
+        "1\t1\ta.raw\tv1.1.0\t{value}\n"
+    )
+
+    def _design(self, factor: str, value: str):
+        content = (self.HEADER.format(factor=factor)
+                   + self.ROW.format(value=value))
+        return score_sdrf(content).design
+
+    def test_factor_backed_by_comment_column_is_accepted(self):
+        dim = self._design("factor value[cross-linker]", "NT=DSSO;AC=XLMOD:02126")
+        assert not any("no matching" in i for i in dim.issues), dim.issues
+
+    def test_factor_backed_by_characteristics_column_is_accepted(self):
+        dim = self._design("factor value[disease]", "normal")
+        assert not any("no matching" in i for i in dim.issues), dim.issues
+
+    def test_factor_backed_by_nothing_is_still_reported(self):
+        dim = self._design("factor value[treatment]", "drug A")
+        assert any("no matching" in i for i in dim.issues), dim.issues

--- a/tools/completeness.py
+++ b/tools/completeness.py
@@ -404,17 +404,26 @@ def _score_design(sdrf: SDRFFile) -> DimensionScore:
     else:
         dim.issues.append("No factor value columns defined")
 
-    # Factor values correspond to characteristics
-    char_names = {c.inner_name.lower() for c in sdrf.columns if c.col_type == "characteristics"}
+    # A factor value must restate a variable declared elsewhere in the file.
+    # That source is usually a characteristics column, but it is legitimately a
+    # comment column when the studied variable is technical: the crosslinking
+    # template declares the cross-linker as comment[cross-linker], so a
+    # cross-linker factor can NEVER have a matching characteristics column.
+    # parse_sdrf accepts either, requiring only that the values match.
+    source_names = {
+        c.inner_name.lower()
+        for c in sdrf.columns
+        if c.col_type in ("characteristics", "comment")
+    }
     for fc in factor_cols:
         checks += 1
         # Extract inner name from "factor value[disease]"
         inner = fc.split("[", 1)[1].rstrip("]").lower() if "[" in fc else ""
-        if inner in char_names:
+        if inner in source_names:
             ok += 1
         else:
             dim.issues.append(
-                f"Factor value '{fc}' has no matching characteristics column"
+                f"Factor value '{fc}' has no matching characteristics or comment column"
             )
 
     # Biological replicate column


### PR DESCRIPTION
## Problem

`_score_design()` resolves each `factor value[...]` column against
**characteristics columns only**:

```python
char_names = {c.inner_name.lower() for c in sdrf.columns if c.col_type == "characteristics"}
```

So any factor on a *technical* variable is reported as

```
Factor value 'factor value[cross-linker]' has no matching characteristics column
```

and costs 25 points of the Design dimension.

**For crosslinking datasets this check can never pass.** The `crosslinking`
template declares the cross-linker as `comment[cross-linker]`, not as a
characteristic — so "the cross-linker was the variable under study", which is
the entire point of an XL-MS benchmark, is unexpressible in a way the scorer
accepts. The same applies to any study whose compared variable is technical:
acquisition method, instrument, dissociation method.

`parse_sdrf` itself accepts a factor value backed by either column type — it
only requires that the factor column and its source column carry identical
values. **The scorer was stricter than the validator.**

## Change

Factor values are resolved against `characteristics` **and** `comment` columns.
A factor backed by neither is still reported, with the message updated to name
both.

## Effect

Found while annotating **PXD014337** (Beveridge et al., *Nat Commun* 2020), a
benchmark whose studied variable *is* the cross-linker:

| | before | after |
|---|---|---|
| PXD014337 | 96/100 (Design 75) | **100/100** (Design 100) |
| PXD020948 (factor on `characteristics[organism part]`) | 100/100 | 100/100 |

No change to either annotation — only to the score.

## Tests

3 regression tests added (`TestFactorValueSource`): a factor backed by a
comment column, one backed by a characteristics column, and one backed by
neither (still reported).

Full suite: **172 passed**. `tests/test_mcp_pride.py` / `tests/test_mcp_server.py`
skipped locally (`fastmcp` not installed; unrelated).