### PR TITLE
feat(tools): detect a systematic run-name suffix mismatch

### DIFF
--- a/tests/test_existing_annotation.py
+++ b/tests/test_existing_annotation.py
@@ -250,3 +250,58 @@ class TestReviewFindings:
                      "NT=y;AC=MS:2", "1", "1", "r1.raw", "c")]
         report = audit(_sdrf(rows), accession="PXD.1")
         assert any(f.code == "source_name_convention" for f in report.findings)
+
+
+class TestRunNameSuffixMismatch:
+    """PRIDE ships Bruker `.d` directories zipped; the SDRF names the `.d`.
+
+    Regression test: a deposited-run list taken straight from the PRIDE file
+    listing put every run in BOTH `missing_runs` and `invented_runs`, emitting
+    2N blockers that read like a wrong annotation and invite a caller to
+    "repair" a correct SDRF.
+    """
+
+    @staticmethod
+    def _sdrf(runs):
+        head = "source name\tcomment[data file]\tfactor value[disease]\n"
+        return head + "".join(f"PXD1-Sample-1\t{r}\tnormal\n" for r in runs)
+
+    def test_zip_suffix_mismatch_reported_once(self):
+        annotated = ["a_1.d", "b_2.d", "c_3.d"]
+        deposited = [f"{r}.zip" for r in annotated]
+        report = audit(self._sdrf(annotated), deposited_runs=deposited)
+        codes = [f.code for f in report.findings]
+        assert "run_name_suffix_mismatch" in codes
+        assert "missing_runs" not in codes
+        assert "invented_runs" not in codes
+        assert sum(c == "run_name_suffix_mismatch" for c in codes) == 1
+
+    def test_identical_sets_produce_no_finding(self):
+        runs = ["a_1.d", "b_2.d"]
+        report = audit(self._sdrf(runs), deposited_runs=runs)
+        codes = [f.code for f in report.findings]
+        assert "run_name_suffix_mismatch" not in codes
+        assert "missing_runs" not in codes
+        assert "invented_runs" not in codes
+
+    def test_genuine_mismatch_still_blocks(self):
+        """A real coverage error must not be excused as a suffix mismatch."""
+        report = audit(self._sdrf(["a_1.d"]), deposited_runs=["a_1.d", "b_2.d"])
+        codes = [f.code for f in report.findings]
+        assert "missing_runs" in codes
+        assert "run_name_suffix_mismatch" not in codes
+
+    def test_partial_suffix_mismatch_still_blocks(self):
+        """Only a wholesale suffix mismatch is benign."""
+        report = audit(self._sdrf(["a_1.d", "b_2.d"]),
+                       deposited_runs=["a_1.d.zip", "c_3.d.zip"])
+        codes = [f.code for f in report.findings]
+        assert "run_name_suffix_mismatch" not in codes
+        assert "missing_runs" in codes and "invented_runs" in codes
+
+    def test_collapsing_names_are_not_treated_as_suffix_mismatch(self):
+        """Two distinct runs must not collapse onto one stripped name."""
+        report = audit(self._sdrf(["x.d", "x.d.zip"]),
+                       deposited_runs=["x.d.zip", "x.d.zip.zip"])
+        codes = [f.code for f in report.findings]
+        assert "run_name_suffix_mismatch" not in codes

--- a/tools/existing_annotation.py
+++ b/tools/existing_annotation.py
@@ -104,6 +104,34 @@ def _values(rows: Iterable[Sequence[str]], idx: Sequence[int]) -> set[str]:
     return {r[i] for r in rows for i in idx if i < len(r)}
 
 
+# Archive wrappers a repository may add around a run. Bruker `.d` is a
+# DIRECTORY, so PRIDE can only ship it zipped; the SDRF names the `.d` itself.
+_ARCHIVE_SUFFIXES = (".tar.gz", ".tar.bz2", ".tar", ".zip", ".7z", ".gz")
+
+
+def _strip_archive_suffix(name: str) -> str:
+    for suffix in _ARCHIVE_SUFFIXES:
+        if name.lower().endswith(suffix) and len(name) > len(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def _same_modulo_archive_suffix(deposited: set[str], annotated: set[str]) -> bool:
+    """True when the two run sets differ only by an archive wrapper.
+
+    Requires both sides to stay the same size after stripping, so that two
+    genuinely different runs collapsing onto one name is not mistaken for a
+    tidy suffix mismatch.
+    """
+    if not deposited or not annotated:
+        return False
+    dep = {_strip_archive_suffix(n) for n in deposited}
+    ann = {_strip_archive_suffix(n) for n in annotated}
+    if len(dep) != len(deposited) or len(ann) != len(annotated):
+        return False
+    return dep == ann
+
+
 def audit(
     sdrf_text: str,
     deposited_runs: Iterable[str] | None = None,
@@ -143,6 +171,26 @@ def audit(
                 "comment[data file] has blank cell(s), so some rows name no run"))
         missing = deposited - annotated
         invented = annotated - deposited
+
+        # A systematic archive-suffix mismatch is not a wrong annotation, but
+        # it presents as one: PRIDE ships Bruker `.d` directories zipped, so a
+        # deposited-run list taken straight from the file listing holds
+        # `<run>.d.zip` while the SDRF (correctly) names `<run>.d`. Every run
+        # then lands in BOTH sets and the audit emits 2N blockers reading
+        # "the annotation does not match the deposit" -- which invites a
+        # caller to "repair" a correct SDRF into a broken one. Detect the
+        # systematic case and report it once, naming the real fix.
+        if missing and invented and _same_modulo_archive_suffix(deposited, annotated):
+            report.findings.append(Finding(
+                "run_name_suffix_mismatch", MAJOR,
+                (f"the {len(deposited)} deposited run(s) and the annotated runs are "
+                 "identical apart from an archive suffix, so neither set is wrong "
+                 "about which runs exist"),
+                ("normalise one side: comment[data file] names the unpacked run "
+                 f"(e.g. {sorted(annotated)[0]}), not the archive PRIDE ships "
+                 f"(e.g. {sorted(deposited)[0]})")))
+            missing = invented = set()
+
         if missing:
             report.findings.append(Finding(
                 "missing_runs", BLOCKER,


### PR DESCRIPTION
## Problem

PRIDE cannot ship a Bruker `.d` run as-is — it is a **directory**, so the
archive holds `<run>.d.zip`, while the SDRF correctly names `<run>.d` (which is
also what MaxQuant's `mqpar.xml` `filePaths` record, and what the community
corpus uses).

So a deposited-run list taken straight from the PRIDE file listing disagrees
with a **perfectly good annotation on every single row**. Because the
comparison is an exact string set diff, every run lands in *both* `missing` and
`invented`:

```
PXD020948 is already annotated (9 rows), but the audit found 2 issue(s):

  BLOCKER  missing_runs: 9 deposited run(s) are not annotated
  BLOCKER  invented_runs: 9 annotated run(s) do not exist in the deposit

suggested action: reannotate
```

Nothing is wrong with that SDRF. The audit tells the caller to **rebuild a
correct annotation from scratch** — and an automated caller will do exactly
that. This is the most damaging class of false positive: it converts a tooling
mismatch into instructions to destroy correct work.

## After

```
PXD020948 is already annotated (9 rows), but the audit found 1 issue(s):

  MAJOR  run_name_suffix_mismatch: the 9 deposited run(s) and the annotated
         runs are identical apart from an archive suffix, so neither set is
         wrong about which runs exist
         [normalise one side: comment[data file] names the unpacked run
          (e.g. ..._2288.d), not the archive PRIDE ships (e.g. ..._2288.d.zip)]

suggested action: fix
```

## Deliberately narrow

The finding replaces the blockers **only** when:

1. the two sets are identical after stripping one archive wrapper
   (`.zip`, `.tar`, `.tar.gz`, `.tar.bz2`, `.7z`, `.gz`), **and**
2. neither set loses an entry to collapsing — so two distinct runs that differ
   only by `.zip` cannot be mistaken for a tidy suffix mismatch.

A genuine coverage error still blocks exactly as before, including a *partial*
overlap. Severity is MAJOR rather than BLOCKER because neither input is wrong
about which runs exist — one of them is merely spelled in the archive's terms.

## Tests

5 regression tests: wholesale mismatch reported once, identical sets clean,
a genuine missing run still blocks, a partial mismatch still blocks, and the
name-collapsing guard.

Full suite: **174 passed**. `tests/test_mcp_pride.py` / `tests/test_mcp_server.py`
skipped locally (`fastmcp` not installed; unrelated).