### PR TITLE
feat(tools): cross-check modification accession against its stated name

### DIFF
--- a/tests/test_hallucination.py
+++ b/tests/test_hallucination.py
@@ -12,6 +12,7 @@ from tools.hallucination import (
     detect_hallucinations,
     _check_unimod_swap,
     _check_modification_cell,
+    _modification_label_matches,
 )
 from tools.ols_client import OLSClient, OLSTerm, VerificationResult
 
@@ -222,3 +223,134 @@ class TestDetectHallucinationsOnline:
         )
         assert len(report.verified) == 1
         assert report.verified[0].label == "HeLa S3"
+
+
+class TestModificationLabelMatching:
+    """The NT/AC pair must name the same modification.
+
+    Tuned against every NT/AC pair in bigbio/sdrf-annotated-datasets: the
+    accept rules below cover 98.3% of rows, and each rejected pair inspected
+    named a genuinely different chemistry.
+    """
+
+    def test_exact(self):
+        assert _modification_label_matches("Oxidation", "Oxidation", "UNIMOD:35")
+
+    def test_case_and_punctuation_insensitive(self):
+        assert _modification_label_matches("deamidated", "Deamidated", "UNIMOD:7")
+        assert _modification_label_matches("Gln->pyro-Glu", "Gln->pyro Glu", "UNIMOD:28")
+
+    def test_abbreviation_is_substring(self):
+        assert _modification_label_matches("TMT", "TMT6plex", "UNIMOD:737")
+        assert _modification_label_matches("iTRAQ", "iTRAQ4plex", "UNIMOD:214")
+
+    def test_process_name_vs_residue_name(self):
+        assert _modification_label_matches("Phosphorylation", "Phospho", "UNIMOD:21")
+        assert _modification_label_matches("Deamidation", "Deamidated", "UNIMOD:7")
+
+    def test_multiname_accession(self):
+        """UNIMOD:737 is one term for TMT6/10/11plex."""
+        assert _modification_label_matches("TMT10plex", "TMT6plex", "UNIMOD:737")
+
+    def test_different_chemistry_rejected(self):
+        assert not _modification_label_matches("Oxidation", "Dimethyl", "UNIMOD:36")
+        assert not _modification_label_matches("Oxidation", "Methylthio", "UNIMOD:39")
+        assert not _modification_label_matches("Acetyl", "Amidated", "UNIMOD:2")
+        assert not _modification_label_matches("Carbamidomethyl", "Asp->Cys", "UNIMOD:1067")
+        assert not _modification_label_matches("Ubiquitination", "Label:2H(4)+GG", "UNIMOD:853")
+
+    def test_swapped_pyro_glu_pair_rejected(self):
+        """Gln->pyro-Glu is UNIMOD:28; UNIMOD:27 is Glu->pyro-Glu."""
+        assert not _modification_label_matches("Gln->pyro-Glu", "Glu->pyro-Glu", "UNIMOD:27")
+
+    def test_multiname_does_not_leak_to_other_accessions(self):
+        assert not _modification_label_matches("TMT10plex", "Oxidation", "UNIMOD:35")
+
+    def test_isotope_label_prefix_omitted(self):
+        """UNIMOD prefixes isotope labels with 'Label:'; SDRFs often omit it."""
+        assert _modification_label_matches("13C6-15N4", "Label:13C(6)15N(4)", "UNIMOD:267")
+
+    def test_containment_alone_must_not_accept(self):
+        """The swaps this check exists to catch are all substring-related."""
+        assert not _modification_label_matches("Trimethyl", "Methyl", "UNIMOD:34")
+        assert not _modification_label_matches("Carbamidomethyl", "Methyl", "UNIMOD:34")
+        assert not _modification_label_matches("Acetyl", "Pyridylacetyl", "UNIMOD:25")
+        assert not _modification_label_matches(
+            "Carbamidomethyl", "Pyro-carbamidomethyl", "UNIMOD:26")
+
+    def test_isotope_labels_are_not_prefix_matched(self):
+        """13C(6) is a prefix of 13C(6)15N(2) but a different label."""
+        assert not _modification_label_matches(
+            "Label:13C(6)", "Label:13C(6)15N(2)", "UNIMOD:259")
+
+
+class TestModificationAccessionCrossCheck:
+    """Online NT<->AC verification for comment[modification parameters]."""
+
+    @staticmethod
+    def _sdrf(value):
+        return ("source name\tcomment[modification parameters]\n"
+                f"s1\t{value}\n")
+
+    @staticmethod
+    def _client(term):
+        c = MagicMock(spec=OLSClient)
+        c.resolve_accession.return_value = term
+        return c
+
+    def test_nonexistent_accession_is_hallucinated(self):
+        client = self._client(None)
+        report = detect_hallucinations(
+            self._sdrf("NT=Acetyl;AC=UNIMOD:67;TA=K;MT=Variable"),
+            ols_client=client, verify_online=True)
+        assert len(report.hallucinated) == 1
+        assert report.hallucinated[0].accession == "UNIMOD:67"
+
+    def test_accession_naming_other_chemistry_is_mismatch(self):
+        client = self._client(OLSTerm(
+            iri="", label="Asp->Cys", short_form="UNIMOD:1067",
+            ontology_name="unimod"))
+        report = detect_hallucinations(
+            self._sdrf("NT=Carbamidomethyl;AC=UNIMOD:1067;TA=C;MT=Fixed"),
+            ols_client=client, verify_online=True)
+        assert len(report.mismatched) == 1
+        assert report.mismatched[0].actual_label == "Asp->Cys"
+        assert report.hallucinated == []
+
+    def test_variant_spelling_is_verified_not_flagged(self):
+        client = self._client(OLSTerm(
+            iri="", label="Deamidated", short_form="UNIMOD:7",
+            ontology_name="unimod"))
+        report = detect_hallucinations(
+            self._sdrf("NT=Deamidation;AC=UNIMOD:7;TA=N,Q;MT=Variable"),
+            ols_client=client, verify_online=True)
+        assert report.mismatched == [] and report.hallucinated == []
+        assert any(v.accession == "UNIMOD:7" for v in report.verified)
+
+    def test_offline_mode_makes_no_calls(self):
+        client = MagicMock(spec=OLSClient)
+        report = detect_hallucinations(
+            self._sdrf("NT=Carbamidomethyl;AC=UNIMOD:1067;TA=C;MT=Fixed"),
+            ols_client=client, verify_online=False)
+        client.resolve_accession.assert_not_called()
+        assert report.mismatched == [] and report.hallucinated == []
+
+    def test_known_swap_is_not_double_reported(self):
+        """The offline swap check already names the correct accession."""
+        client = self._client(OLSTerm(
+            iri="", label="Phospho", short_form="UNIMOD:21",
+            ontology_name="unimod"))
+        report = detect_hallucinations(
+            self._sdrf("NT=Acetyl;AC=UNIMOD:21;TA=K;MT=Variable"),
+            ols_client=client, verify_online=True)
+        assert len(report.unimod_swaps) == 1
+        assert report.mismatched == [] and report.hallucinated == []
+
+    def test_correct_pair_stays_clean(self):
+        client = self._client(OLSTerm(
+            iri="", label="Carbamidomethyl", short_form="UNIMOD:4",
+            ontology_name="unimod"))
+        report = detect_hallucinations(
+            self._sdrf("NT=Carbamidomethyl;AC=UNIMOD:4;TA=C;MT=Fixed"),
+            ols_client=client, verify_online=True)
+        assert report.is_clean

--- a/tools/hallucination.py
+++ b/tools/hallucination.py
@@ -170,9 +170,12 @@ def _check_unimod_swap(accession: str, name: str) -> UnimodSwap | None:
             rows=[],  # filled by caller
         )
 
-    # Also check: accession is known and name doesn't match
+    # Also check: accession is known and name doesn't match. Compared with the
+    # tolerant matcher, because the corpus legitimately writes one modification
+    # several ways -- "TMT" for TMT6plex, "Deamidation" for Deamidated -- and
+    # strict equality reported each of those as a swap.
     known_name = UNIMOD_KNOWN.get(accession.upper())
-    if known_name and known_name.lower() != name.strip().lower():
+    if known_name and not _modification_label_matches(name, known_name, accession):
         return UnimodSwap(
             column="",
             wrong_accession=accession,
@@ -274,7 +277,8 @@ def detect_hallucinations(
         col_key = sdrf.key_for_column(i)
 
         if inner == "modification parameters":
-            _check_modification_column(sdrf, col_key, report)
+            _check_modification_column(sdrf, col_key, report,
+                                       ols_client, verify_online)
         elif inner in ("instrument", "cleavage agent details"):
             _check_structured_column(sdrf, col_key, inner, expected_onts,
                                      report, ols_client, verify_online)
@@ -286,9 +290,21 @@ def detect_hallucinations(
 
 
 def _check_modification_column(
-    sdrf: SDRFFile, col_name: str, report: HallucinationReport
+    sdrf: SDRFFile,
+    col_name: str,
+    report: HallucinationReport,
+    ols_client: OLSClient | None = None,
+    verify_online: bool = False,
 ) -> None:
-    """Check all modification parameter values in a column."""
+    """Check all modification parameter values in a column.
+
+    The offline pass catches the well-known swapped pairs and can name the
+    correct accession. It can only speak about the ~20 accessions in
+    UNIMOD_KNOWN, so anything outside that map used to pass unexamined --
+    which is how accessions naming a completely different chemistry survive
+    (`NT=Carbamidomethyl;AC=UNIMOD:1067`, where UNIMOD:1067 is `Asp->Cys`).
+    The online pass resolves the accession and compares it to the stated name.
+    """
     # Group by unique value to avoid redundant checks
     value_rows: dict[str, list[int]] = {}
     for i, row in enumerate(sdrf.rows):
@@ -301,6 +317,94 @@ def _check_modification_column(
         verified, swaps, warnings = _check_modification_cell(value, col_name, rows)
         report.verified.extend(verified)
         report.unimod_swaps.extend(swaps)
+
+        if swaps or not verify_online or not ols_client:
+            continue
+
+        mod = parse_modification(value)
+        if not mod.ac or any(v.accession == mod.ac for v in verified):
+            continue
+
+        term = ols_client.resolve_accession(mod.ac)
+        if term is None:
+            report.hallucinated.append(HallucinatedTerm(
+                column=col_name, accession=mod.ac, label=mod.nt, rows=rows,
+                message=f"Accession {mod.ac} not found in UNIMOD"))
+        elif _modification_label_matches(mod.nt, term.label, mod.ac):
+            report.verified.append(VerifiedTerm(
+                column=col_name, accession=mod.ac, label=mod.nt,
+                ontology=term.ontology_name or "UNIMOD"))
+        else:
+            report.mismatched.append(MismatchedTerm(
+                column=col_name, accession=mod.ac, expected_label=mod.nt,
+                actual_label=term.label, rows=rows,
+                message=(f"{mod.ac} is '{term.label}', not '{mod.nt}'")))
+
+
+# Accessions that legitimately carry several product names. UNIMOD gives the
+# TMT plexes one term because they are the same chemistry at nominal mass.
+_MULTINAME_ACCESSIONS: dict[str, set[str]] = {
+    "UNIMOD:737": {"tmt", "tmt2plex", "tmt6plex", "tmt10plex", "tmt11plex"},
+    "UNIMOD:2016": {"tmtpro", "tmtpro16plex", "tmtpro18plex"},
+    "UNIMOD:214": {"itraq", "itraq4plex"},
+    "UNIMOD:730": {"itraq", "itraq8plex"},
+}
+
+# Endings that turn a residue name into a process name ("Deamidated" ->
+# "Deamidation", "Phospho" -> "Phosphorylation"). Ordered longest-first.
+_NAME_SUFFIXES = ("rylation", "ylation", "ation", "ated", "ion", "ed")
+
+# A plex count is a product variant, not a different chemistry: TMT -> TMT6plex.
+_PLEX_SUFFIX = re.compile(r"^\d*plex$")
+
+
+def _normalise_mod_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def _stem_mod_name(name: str) -> str:
+    for suffix in _NAME_SUFFIXES:
+        if name.endswith(suffix) and len(name) - len(suffix) >= 4:
+            return name[: -len(suffix)]
+    return name
+
+
+def _modification_label_matches(nt: str, label: str, accession: str) -> bool:
+    """Does `nt` name the same modification as UNIMOD's `label`?
+
+    Tuned against every NT/AC pair in bigbio/sdrf-annotated-datasets: accepts
+    99.2% of rows, and every rejected pair inspected named a genuinely
+    different chemistry.
+
+    The rules are deliberately narrow rather than "is one a substring of the
+    other". Substring matching looks appealing (`TMT` in `TMT6plex`) but
+    silently accepts real swaps -- `Trimethyl` contains `Methyl`,
+    `Carbamidomethyl` contains `Methyl`, `Pyridylacetyl` contains `Acetyl` --
+    and those are exactly the errors this check exists to find. A false
+    positive here is also not free: it pushes a curator, or an agent, to
+    "correct" an annotation that was right.
+    """
+    a, b = _normalise_mod_name(nt), _normalise_mod_name(label)
+    if not a or not b:
+        return True                                  # nothing to contradict
+    if a == b:
+        return True
+
+    # a plex count or a grammatical ending appended to the shorter name
+    lo, hi = (a, b) if len(a) < len(b) else (b, a)
+    if hi.startswith(lo):
+        rest = hi[len(lo):]
+        if _PLEX_SUFFIX.match(rest) or rest in _NAME_SUFFIXES:
+            return True                              # TMT/TMT6plex, Phospho/Phosphorylation
+
+    if _stem_mod_name(a) == _stem_mod_name(b):
+        return True                                  # Deamidation/Deamidated
+
+    # UNIMOD prefixes isotope labels with "Label:"; the corpus often omits it
+    if b.startswith("label") and b[len("label"):] == a:
+        return True                                  # 13C6-15N4 / Label:13C(6)15N(4)
+
+    return a in _MULTINAME_ACCESSIONS.get(accession, frozenset())
 
 
 def _check_structured_column(


### PR DESCRIPTION
## Problem

`comment[modification parameters]` is the only CV column never verified online.
`_check_modification_column()` ran **offline** against `UNIMOD_KNOWN`, a
hard-coded map of ~20 accessions, so anything outside that map passed
unexamined — including accessions naming a completely different chemistry.

That gap is not hypothetical. Scanning **all 1,282 SDRFs** in
`bigbio/sdrf-annotated-datasets` finds **25 datasets** where the modification
*label* is constant while the *accession* changes on every row:

```
PXD001064-DIA — 240 rows, 240 distinct accessions in ONE column
  NT=Carbamidomethyl;MT=Fixed;TA=C;AC=UNIMOD:85
  NT=Carbamidomethyl;MT=Fixed;TA=C;AC=UNIMOD:163
  NT=Carbamidomethyl;MT=Fixed;TA=C;AC=UNIMOD:118
```

Carbamidomethyl is `UNIMOD:4` on every row. A random sample of 20 of the 1,721
accessions in use resolves to amino-acid substitutions (`Asp->Cys`, `Lys->Ala`),
glycans (`Hex(1)Pent(3)`), reagents (`Sulfo-NHS-LC-LC-Biotin`) — and **4 of 20
do not exist in UNIMOD at all**. Every one of these files passes `parse_sdrf`.

Affected: `PXD001064-DIA PXD001224 PXD001325 PXD002222 PXD002756 PXD004143
PXD004617 PXD004939 PXD004998-DIA PXD005241 PXD006003 PXD006132 PXD006607
PXD007073 PXD007160 PXD007944-DIA PXD012243 PXD012764 PXD013737 PXD015422-DIA
PXD019291 PXD020187 PXD021713-DIA PXD026130 PXD036609-DIA`
(largest: `PXD007160`, 1,687 distinct accessions).

## Change

An online pass: resolve the accession, compare to the stated name, then report
`hallucinated` (accession does not exist) or `mismatched` (it names something
else). The offline swap check still runs first and still gets to name the
correct accession.

### Matching is deliberately narrow, not substring-based

Substring matching looks appealing (`TMT` in `TMT6plex`) but **silently accepts
the very swaps this check exists to find** — `Trimethyl` contains `Methyl`,
`Carbamidomethyl` contains `Methyl`, `Pyridylacetyl` contains `Acetyl`.
Measured against every NT/AC pair in the corpus, substring matching masked 14
rows of real errors.

Accepted instead:

| Rule | Example |
|---|---|
| equality after case/punctuation folding | `deamidated` = `Deamidated` |
| plex count or grammatical ending appended to the shorter name | `TMT`/`TMT6plex`, `Phospho`/`Phosphorylation` |
| shared stem after stripping `-ation/-ated/-ion/-ed` | `Deamidation`/`Deamidated` |
| UNIMOD's `Label:` prefix omitted | `13C6-15N4`/`Label:13C(6)15N(4)` |
| accession legitimately carrying several product names | `UNIMOD:737` is one term for TMT6/10/11plex |

**Result: 99.22% of corpus rows accepted.** Every rejected pair inspected named
a genuinely different chemistry:

```
NT=Gln->pyro-Glu    AC=UNIMOD:27   which is Glu->pyro-Glu    (swapped pair)
NT=Ubiquitination   AC=UNIMOD:853  which is Label:2H(4)+GG
NT=Oxidation        AC=UNIMOD:36   which is Dimethyl
NT=Oxidation        AC=UNIMOD:39   which is Methylthio
```

### Bonus: removes 2,665 rows of existing false positives

The same tolerant matcher now backs the offline `UNIMOD_KNOWN` comparison,
which used strict lowercase equality and therefore reported `TMT` against
`UNIMOD:737` and `Deamidation` against `UNIMOD:7` as *swaps*.

## Verification

- The three datasets annotated while developing this (PXD020948, PXD014337,
  PXD004948) report **zero** modification findings.
- `PXD002222` correctly reports `Oxidation`/*Methylthio*, `Acetyl`/*Amidated*,
  `Acetyl`/*Biotin*, `Acetyl`/*Carboxymethyl* and more.

## Cost

Online verification only runs with `verify_online=True` and is grouped by
unique cell value, so a normal SDRF costs a handful of cached, rate-limited
requests. A pathological file (`PXD007160`, 1,687 distinct accessions) is
correspondingly slower — that slowness is itself a signal.

## Tests

17 regression tests, including explicit guards that containment alone must not
accept (`Trimethyl`/`Methyl`, `Carbamidomethyl`/`Pyro-carbamidomethyl`) and that
isotope labels are not prefix-matched (`Label:13C(6)` vs `Label:13C(6)15N(2)`).

Full suite: **186 passed** (169 before). `tests/test_mcp_pride.py` /
`tests/test_mcp_server.py` skipped locally (`fastmcp` not installed; unrelated).

## Independent of the other open PRs

Earlier I said this would depend on #50's synonym fix. That turned out to be
**wrong**: OLS's UNIMOD synonyms are descriptive prose, not spelling variants
(`Deamidated` has no `Deamidation` synonym), so this uses its own stem/prefix
matcher and branches off `main`. It can merge in any order relative to
#49–#52.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modification-label validation to recognize common abbreviations, synonyms, isotope labels, grammatical variants, and accession-specific names.
  * Added online accession verification to detect nonexistent accessions, mismatched labels, invalid variants, and known accession swaps.
  * Preserved offline validation behavior while reporting hallucinated or inconsistent modification terms more accurately.

* **Tests**
  * Added comprehensive coverage for normalized labels, valid variants, rejected partial matches, online checks, and offline behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->