### PR TITLE
docs(annotate): derive modifications from the deposited search files

### DIFF
--- a/annotations/ANNOTATOR_BRIEF.md
+++ b/annotations/ANNOTATOR_BRIEF.md
@@ -50,8 +50,16 @@ mkdir -p "$CLAUDE_SCRATCH/<PXD>/"      # or <repo>/../scratch/<PXD>/ if no scrat
   - Bruker `.d`: `analysis.tdf` is SQLite (`DiaFrameMsMsWindows` = DIA windows), ~15 MB inside a
     multi-GB archive (#33).
   - Deposited search outputs beat Methods prose: MaxQuant `summary.txt`/`parameters.txt`,
-    FragPipe `fragger.params`, DIA-NN logs, Proteome Discoverer `.msf` (SQLite), SpectroMine
-    `.psar` (UTF-16 strings). Often the ONLY source of the channel→sample map.
+    FragPipe `fragger.params`, DIA-NN logs, Proteome Discoverer `.msf`/`.pdStudy` (SQLite),
+    SpectroMine `.psar` (UTF-16 strings). Often the ONLY source of the channel→sample map —
+    **and always the authoritative source of the search modifications.** Derive
+    `comment[modification parameters]` from them, never from paper prose or from what the
+    protocol implies: PD's `Workflows` node XML gives `IntendedPurpose` (`StaticModification`
+    → `MT=Fixed`, `DynamicModification` → `MT=Variable`, any `…TerminalModification` → `PP=`
+    not `TA=`) plus `UnimodAccession` and `CleavageReagent`; MaxQuant `mqpar.xml` gives
+    fixed/variable lists; FragPipe `table.fix-mods`/`table.var-mods`; DIA-NN
+    `--fixed-mod`/`--var-mod`. Read multi-GB `.msf` by HTTP-range SQLite — do not download.
+    Read the modifications and the channel map out of the same file in one pass.
 - **`is_open_access` is unreliable** in PRIDE *and* Europe PMC. A gold-OA CC-BY paper was reported
   `false` by both. Always try `get_pdf_by_unpaywall`; also the PMC HTML render, NCBI eutils, and
   Europe PMC free-text search on the accession itself. Unpaywall has returned anti-bot HTML while
@@ -68,8 +76,14 @@ mkdir -p "$CLAUDE_SCRATCH/<PXD>/"      # or <repo>/../scratch/<PXD>/ if no scrat
 - **UNIMOD:1 = Acetyl, UNIMOD:21 = Phospho.** Positional values go in `PP=`, never `TA=`.
   **Dimethyl trap**: OLS returns `UNIMOD:510` for "Dimethyl" — that is `Dimethyl:2H(4)13C(2)` (+6).
   Heavy +8 is **UNIMOD:330**. Derive each channel from the actual stated mass shift.
-  **Never assert Carbamidomethyl without an alkylation step** — many SCP protocols eliminate
-  reduction/alkylation; the reflex annotation is wrong on every row and passes validation.
+  **Carbamidomethyl cuts both ways.** Never assert it when a source explicitly documents that
+  reduction/alkylation was omitted — many SCP protocols eliminate it, and the reflex annotation
+  is wrong on every row and passes validation. Equally, never drop a Carbamidomethyl the
+  deposited search declares `Fixed` just because the wet-lab reagent is unstated (PXD048052:
+  a closed paper + a "no alkylation" assumption lost against the PD `.msf`, which listed
+  `StaticModification` Carbamidomethyl UNIMOD:4). Silence about the prep is not evidence of no
+  alkylation — the search wins, and the unstated reagent is `not available`, NOT
+  `not applicable`.
 - **"Single-cell-equivalent" is a mass, not a count.** `0.5 ng ≈ 2–3 cells` is a dilution standard:
   `sample type = standard`, `cells per well = not applicable` — not 2 or 3.
 - **Column licensing**: every `characteristics[...]` you use MUST be licensed by a template you

--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -208,8 +208,11 @@ and instrument acquisition — read them BEFORE the publication.
 >   `analysis.tdf` is a SQLite DB (see the Bruker skill, #33).
 > - **Search settings & the channel→sample map** — deposited search outputs beat
 >   Methods prose: MaxQuant `summary.txt`/`parameters.txt`, FragPipe
->   `fragger.params`, DIA-NN logs, PD `.msf` (SQLite). These are often the *only*
->   source of the channel map.
+>   `fragger.params`, DIA-NN logs, PD `.msf`/`.pdStudy` (SQLite), SpectroMine
+>   `.psar`. These are often the *only* source of the channel map, **and they are
+>   the authoritative source of the search modifications** (static/dynamic) that
+>   drive `comment[modification parameters]` — see §5.2.1. Read both out of the
+>   same file in one pass.
 > - **Run names inside huge archives** — read the ZIP central directory via an
 >   HTTP range request rather than downloading a multi-GB archive.
 
@@ -317,7 +320,8 @@ Read the paper systematically and extract:
 - Labeling strategy (which TMT/iTRAQ channels for which samples)
 - Fractionation details (number of fractions, method)
 - Instrument and acquisition method details
-- Modifications searched
+- Modifications searched — the paper is a cross-check here, not the source;
+  the deposited search files decide (§5.2.1)
 
 Demographic evidence rules:
 - `characteristics[developmental stage]` can be added from cohort-level evidence when the whole analyzed cohort is clearly in one stage, for example all subjects are adults or the study is explicitly pediatric.
@@ -617,15 +621,67 @@ Column 3: NT=Acetyl;AC=UNIMOD:1;PP=Protein N-term;MT=Variable
 **Double-check**: UNIMOD:1 = Acetyl, UNIMOD:21 = Phospho. Most common swap!
 For TMT: UNIMOD:737 (TMT6/10/11plex) or UNIMOD:2016 (TMTpro 16/18plex)
 
+#### 5.2.1 Read the modifications out of the deposited search — do not infer them
+`comment[modification parameters]` describes **what the search actually did**, so derive
+it from the deposited search files. Paper Methods, PRIDE's `modifications` field (often
+"No PTMs are included in the dataset" while the search used several), and reasoning from
+the protocol are all downstream of it. Precedence: **deposited search settings > paper
+Methods > PRIDE fields**. Open the search files *before* writing the columns — the same
+files you open for the channel→sample map (Step 1.1) carry the modifications, so read
+both out in one pass.
+
+| Search engine | Deposited file | Where the modifications are |
+|---|---|---|
+| Proteome Discoverer | `.msf`, `.pdStudy`, `.pdResult` (SQLite) | `Workflows` table → processing-node XML |
+| MaxQuant | `parameters.txt`, `mqpar.xml` | `Fixed modifications` / `Variable modifications` |
+| FragPipe / MSFragger | `fragger.params` | `table.fix-mods` / `table.var-mods` |
+| DIA-NN | `report.log.txt` / logged command line | `--fixed-mod`, `--var-mod` (`--unimod4` = fixed Carbamidomethyl) |
+| Spectronaut / SpectroMine | `.psar`, exported settings (UTF-16 strings) | modification list in the settings block |
+
+**Proteome Discoverer `.msf` — read it, never download it.** `.msf`/`.pdResult` are SQLite
+databases and routinely multi-GB (10.5 GB in the case below). Read them with HTTP
+byte-range requests over the SQLite pages, the same way you range-read a ZIP central
+directory. The `Workflows` table stores each processing node's XML, which names every
+modification verbatim with its purpose, its UNIMOD id and its target:
+
+| XML `IntendedPurpose` | SDRF |
+|---|---|
+| `StaticModification` | `MT=Fixed`, residue → `TA=` |
+| `DynamicModification` | `MT=Variable`, residue → `TA=` |
+| any `…TerminalModification` (e.g. `StaticTerminalModification`) | same `Fixed`/`Variable` split, terminus → `PP=`, **never** `TA=` |
+
+`UnimodAccession="4"` → `AC=UNIMOD:4`. The node XML also carries `CleavageReagent`
+(→ `comment[cleavage agent details]`), so one read yields both.
+
+*Worked example (PXD048052)*: the paper was closed (abstract only), and the producer
+reasoned that the "microHOLD" single-cell protocol skips reduction/alkylation, so it
+omitted Carbamidomethyl and set `comment[reduction reagent]` and
+`comment[alkylation reagent]` to `not applicable`. The deposited PD `.msf` said
+otherwise — `StaticModification` Carbamidomethyl/+57.021 Da (C), `UnimodAccession="4"`;
+`DynamicModification` Oxidation/+15.995 Da (M), `UnimodAccession="35"`;
+`StaticModification` + `StaticTerminalModification` TMT6plex (K / Any N-Term),
+`UnimodAccession="737"`; `CleavageReagent` Trypsin (Full). Both missing modifications
+had to be added and the reagent claims retracted.
+
+**Reserved word for an undocumented reagent.** A fixed Carbamidomethyl in the deposited
+search means alkylation was in the search space. If no primary source states which
+reagent the prep used, set `comment[reduction reagent]` / `comment[alkylation reagent]`
+to `not available` (used, unspecified) — **not** `not applicable`, which asserts the step
+did not happen and contradicts the search you just read.
+
 **Domain traps — verify, don't reflex** (each is validator-clean when wrong):
 - **Dimethyl**: OLS returns `UNIMOD:510` for "Dimethyl" — that is
   `Dimethyl:2H(4)13C(2)` (+6). The plain light label is `UNIMOD:36`; heavy **+8
   is `UNIMOD:330`**. Match the mass to the labelling scheme; don't take the first hit.
-- **Carbamidomethyl requires an alkylation step.** Do NOT assert
-  `NT=Carbamidomethyl;AC=UNIMOD:4` when the protocol explicitly omits
-  reduction/alkylation — it is then wrong on every row (and passes validation).
-  When the deposited search params and the paper's Methods disagree, the search
-  params win (precedence: raw > Methods > PRIDE).
+- **Carbamidomethyl cuts both ways — the deposited search decides.** Do NOT
+  assert `NT=Carbamidomethyl;AC=UNIMOD:4` when a primary source *explicitly*
+  documents that reduction/alkylation was omitted (common in SCP protocols) — it
+  is then wrong on every row and passes validation. But the inverse error is just
+  as real: do NOT drop a Carbamidomethyl that the deposited search declares
+  `Fixed` merely because the wet-lab reagent is unstated (§5.2.1, PXD048052).
+  Silence about the prep is not evidence of no alkylation. When the deposited
+  search params and the paper's Methods disagree, the search params win
+  (precedence: raw > Methods > PRIDE).
 - **Cell-line identity is a research task, not a lookup.** Pierce HeLa digest
   standard is **HeLa S3** (`CVCL_0058`), not parental HeLa (`CVCL_0030`);
   ATCC-purchased Jurkat is the **E6-1 clone** (`CVCL_0367`), not the naive


### PR DESCRIPTION
Closes #37.

## Gap

Both documents framed the deposited search outputs (PD `.msf`/`.pdStudy`, MaxQuant, FragPipe, DIA-NN, SpectroMine) almost entirely as **the source of the channel→sample map** — `ANNOTATOR_BRIEF.md` even said "Often the ONLY source of the channel→sample map", and `sdrf-annotate/SKILL.md` never mentioned `.msf` in its modification guidance at all. So an annotator opens the `.msf` for channels and then derives `comment[modification parameters]` from paper prose or from what the protocol implies.

On PXD048052 that cost a fixed Carbamidomethyl and a variable Oxidation, and produced `comment[reduction reagent]` / `comment[alkylation reagent]` = `not applicable` claims that the deposited search directly contradicted.

## Changes

**`skills/sdrf-annotate/SKILL.md`**

- New **§5.2.1 "Read the modifications out of the deposited search — do not infer them"**: the deposited search is the source of truth for `comment[modification parameters]`, with a per-engine table of which file and which field carries the fixed/variable lists (PD `Workflows` node XML, MaxQuant `parameters.txt`/`mqpar.xml`, FragPipe `table.fix-mods`/`table.var-mods`, DIA-NN `--fixed-mod`/`--var-mod`, SpectroMine `.psar`).
- How to read a PD `.msf`: HTTP-range SQLite rather than downloading (they run to multi-GB), the `Workflows` table's processing-node XML, and the `IntendedPurpose` → `MT=Fixed`/`MT=Variable` mapping — with any `…TerminalModification` going to `PP=` and **never** `TA=`. The same XML also yields `CleavageReagent`, so one read serves two columns.
- The PXD048052 miss written up as a worked example.
- **Reserved-word rule**: an alkylation step present in the search but with an unstated reagent is `not available` (used, unspecified), not `not applicable` (asserts it did not happen). Both are legal for these columns per `TERMS.tsv` (`allow_not_available` and `allow_not_applicable` are `true` for `reduction reagent` / `alkylation reagent`, PRIDE:0000607 / PRIDE:0000598), so only meaning separates them — which is exactly why the wrong one passes validation.
- The Carbamidomethyl trap now states **both** directions: do not assert it when a primary source documents that reduction/alkylation was omitted (the SCP case the guidance already covered), and do not drop it when the deposited search declares it `Fixed` and the prep is merely silent (the inverse case #37 reports).
- Step 1.1's precedence blockquote and Step 1.4's "Modifications searched" bullet now point at the search files for modifications, not just for the channel map.

**`annotations/ANNOTATOR_BRIEF.md`** — the same two changes (deposited-search bullet, Carbamidomethyl bullet) in the brief's compressed form, so the two copies do not desync.

## Scope

Docs/skills only; no code changes. `skills/**` is outside the CI path filter, so no test covers this — full suite run locally anyway: **229 passed** (this branch is off `main`, which does not yet carry #55's 14 new tests).

The related `#36` (external repos for channel maps) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw)_