### PR TITLE
docs(annotate): follow Data Availability links when hunting a channel map

### DIFF
--- a/annotations/ANNOTATOR_BRIEF.md
+++ b/annotations/ANNOTATOR_BRIEF.md
@@ -103,10 +103,19 @@ An SDRF needs one row per (file × label channel), each with a sample identity.
 - **Label-free, 1 file = 1 cell** → annotatable.
 - **Multiplexed** (TMT/plexDIA/dimethyl): you MUST find the channel→sample map. Check the paper +
   supplementary, the deposited result tables (Proteome Discoverer defaults every channel to
-  `"Sample, n/a"` = NO map; SpectroMine `.psar` likewise), `files/all` for a sample sheet, and
+  `"Sample, n/a"`, and `StudyInformation.txt` to a bare `"Sample"` with empty groups = NO map;
+  SpectroMine `.psar` likewise), `files/all` for a sample sheet, and
   `https://www.ebi.ac.uk/europepmc/webservices/rest/<PMCID>/supplementaryFiles`.
+  **Then follow the paper's Data Availability / Code Availability links** — Zenodo
+  (`https://zenodo.org/api/records/<id>`), figshare, OSF, Dryad, or the analysis GitHub repo.
+  The layout files (`label_layout`, `sort_layout`, `sample_layout`, `file_sample_mapping`,
+  `annotation.csv`, FACS exports) are deposited there far more often than in PRIDE: PXD053053
+  was a false BLOCK until its Zenodo record (12615623) turned it into 1344 annotatable rows,
+  cross-validated against the deposited `.h5ad` with 0 discrepancies. Reconstruct the map
+  deterministically and cross-check it against a collated result object where one exists.
   Layouts can **flip between runs** — never assume one fixed layout.
-  If no map exists → **BLOCKED**. Do not fabricate channel identities. Write the report +
+  If no map exists → **BLOCKED**, but only after those external sources are exhausted too;
+  name every source checked in the report. Do not fabricate channel identities. Write the report +
   BLOCKED.md entry. A partial annotation (one arm annotatable, another not) is legitimate.
 - Supplementary per-sample tables are gold — but verify they belong to YOUR paper.
 

--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -318,6 +318,10 @@ Read the paper systematically and extract:
 - Developmental stage when the cohort is clearly adult, pediatric, fetal, juvenile, etc.
 - Experimental conditions (treatment, disease state, time points)
 - Labeling strategy (which TMT/iTRAQ channels for which samples)
+- **The Data Availability and Code Availability statements** — copy every
+  accession, DOI and URL they cite (Zenodo, figshare, OSF, Dryad, GitHub).
+  For a multiplexed dataset these links are frequently where the channel→sample
+  map actually lives; see Step 6.1.
 - Fractionation details (number of fractions, method)
 - Instrument and acquisition method details
 - Modifications searched — the paper is a cross-check here, not the source;
@@ -759,6 +763,58 @@ mass tolerances, and undeclared or incorrect modifications.
 ```text
 Total rows = samples × fractions × label_channels × technical_replicates
 ```
+
+### 6.1 Multiplexed: exhaust every source of the channel→sample map before BLOCKING
+For TMT / TMTpro / plexDIA / dimethyl, each of the N rows per file needs a sample
+identity, and inventing one is the worst failure this skill can produce. But a
+missing map inside PRIDE is **not** proof that no map exists — for several
+SCoPE2-lineage studies the layout files are deposited *outside* PRIDE entirely.
+Work the ladder in order, and record in the report which rungs you checked:
+
+1. **The paper + its supplementary** — a per-channel table, often Table S1.
+2. **Deposited PRIDE files** (`files/all`) — a sample sheet, or per-channel sample
+   names in the result tables. Beware the defaults that look like a map and are
+   not: Proteome Discoverer writes every channel as `"Sample, n/a"` (and
+   `StudyInformation.txt` as a bare `"Sample"` with empty groups), SpectroMine
+   likewise. A generic label in all channels of all files means **no map**.
+3. **Europe PMC supplementary** —
+   `https://www.ebi.ac.uk/europepmc/webservices/rest/<PMCID>/supplementaryFiles`.
+4. **External repositories cited in the Data Availability / Code Availability
+   statement** (Step 1.4) — the rung most often skipped:
+
+| Repository | Where to look |
+|---|---|
+| Zenodo | `https://zenodo.org/api/records/<record_id>` → `files[].links.self` |
+| figshare | `https://api.figshare.com/v2/articles/<article_id>` |
+| OSF | `https://api.osf.io/v2/nodes/<node_id>/files/` |
+| Dryad | `https://datadryad.org/api/v2/datasets/doi%3A<encoded DOI>` |
+| GitHub | the analysis repo — `annotation.csv`, layout/design files, the SCeptre/SCoPE2 config |
+
+   Look for layout and sort files by name: `label_layout`, `sort_layout`,
+   `sample_layout`, `file_sample_mapping`, `annotation.csv`, FACS exports, or a
+   collated result object (`.h5ad`, `.rds`).
+
+5. **Cross-validate what you reconstruct.** Rebuild the (file × channel) → sample
+   map deterministically from the layout files, then check it against an
+   independent artifact — the collated `.h5ad`/result matrix's cell identifiers,
+   or the FACS export's per-cell records. Report the discrepancy count; a
+   reconstruction you cannot cross-check is a hypothesis, not a map.
+
+Layouts can **flip between runs** — never assume one layout covers every file.
+Only after all five rungs are exhausted is the dataset BLOCKED; say in the report
+which sources you checked and what each returned, so the block is auditable
+rather than a shrug.
+
+> **Worked example (PXD053053, TMTpro-16).** PRIDE had no usable map — the
+> deposited PD `StudyInformation.txt` marked all 16 channels of all 96 files with
+> the generic default, and the supplementary `mmc1.xlsx` was a generic-labelled
+> abundance matrix. The real map was in the paper's **Zenodo deposit (record
+> 12615623)**, cited in Data Availability: SCeptre `label_layout` / `sort_layout` /
+> `sample_layout` / `file_sample_mapping`, plus `compiled_FACS_data.txt` (all 1152
+> sorted cells with hypoxia time point and FUCCI phase) and
+> `scMS_filtered_data.h5ad`. Reconstructed from the layout files and cross-checked
+> against the h5ad QC cells: **0 discrepancies**, 1344 annotatable rows instead of
+> a false BLOCK. PXD040455's map was likewise in a published Table S1, not in PRIDE.
 
 ## Step 7: Set Factor Values
 


### PR DESCRIPTION
Closes #36.

## Gap

The channel→sample map hunt pointed at the paper + supplementary, the deposited PRIDE files, and Europe PMC — but never at the external repositories cited in the paper's **Data Availability / Code Availability** statement. `grep -ri 'zenodo\|figshare\|osf\|data availability' skills/ annotations/ANNOTATOR_BRIEF.md` returned nothing.

For a multiplexed dataset that makes the difference between a 1344-row SDRF and a false BLOCK, which is the most expensive wrong answer this skill can give: PXD053053's layout files were on Zenodo (record 12615623), not in PRIDE.

## Changes

**`skills/sdrf-annotate/SKILL.md`**

- New **§6.1 "Multiplexed: exhaust every source of the channel→sample map before BLOCKING"** — a five-rung ladder (paper/SI → deposited PRIDE files → Europe PMC supplementary → external repos → cross-validation), placed in Step 6 where files are mapped to samples.
- The external-repo rung carries the actual entry points: Zenodo `api/records/<id>`, figshare `api/v2/articles/<id>`, OSF `api/v2/nodes/<id>/files/`, Dryad `api/v2/datasets/doi%3A<doi>`, and the analysis GitHub repo — plus the filenames worth grepping for (`label_layout`, `sort_layout`, `sample_layout`, `file_sample_mapping`, `annotation.csv`, FACS exports, `.h5ad`/`.rds`).
- Names the two defaults that **impersonate** a map, so an agent doesn't stop early on one: PD's per-channel `"Sample, n/a"` and `StudyInformation.txt`'s bare `"Sample"` with empty groups. A generic label in all channels of all files means no map.
- Requires the reconstruction to be **cross-validated** against an independent artifact and the discrepancy count reported — "a reconstruction you cannot cross-check is a hypothesis, not a map". This is what gave PXD053053's map its 0-discrepancy check against the deposited `.h5ad`.
- BLOCKED is legitimate only after all five rungs, and the report must name each source checked and what it returned, so a block is auditable rather than a shrug.
- Step 1.4 now extracts the Data/Code Availability statements while the paper is open — the links have to be captured there to be followed in Step 6.

**`annotations/ANNOTATOR_BRIEF.md`** — the same change to the multiplexed annotatability bullet, in the brief's compressed form, including the PXD053053 outcome.

## Scope

Docs/skills only, no code. `skills/**` is outside the CI path filter, so nothing here is test-covered; suite run locally anyway: **243 passed**.

The issue's related case PXD040455 (map published as Table S1) is covered by rung 1 and cited in the worked example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw)_