### PR TITLE
docs(metascreen): screen multiplexed datasets for a channel→sample map

### DIFF
--- a/criteria/single_cell_proteomics.md
+++ b/criteria/single_cell_proteomics.md
@@ -63,6 +63,23 @@ by evidence. Keep values short and analysis-ready.
 - `carrier_channel` — `yes` / `no` / `unclear`. Whether a booster/carrier proteome
   channel is used (characteristic of SCoPE-MS/SCoPE2). Load-bearing: the carrier is
   a distinct sample in SDRF and is a classic annotation error when omitted.
+- `channel_map` — `yes` / `no` / `label free` / `unclear`. Whether the deposited
+  evidence records **which label channel of which run held which sample**. This is
+  the annotatability gate for multiplexed studies: without it an SDRF needs one row
+  per (file × channel) and every one of those rows would have a fabricated identity.
+  - `label free` when `labelling` is `label free` — file→cell is 1:1 and the
+    question does not arise. (Not `not applicable`: that is an SDRF reserved word
+    and this is not an SDRF.)
+  - `yes` when a real map exists — a deposited sample sheet, per-channel sample
+    names in the result tables, an explicit channel table in the paper or SI, or
+    layout files in an external repository cited in Data Availability (Zenodo,
+    figshare, OSF, Dryad, GitHub).
+  - `no` when those are exhausted and every channel carries a placeholder.
+    Proteome Discoverer's `"Sample, n/a"` per channel, `StudyInformation.txt`'s
+    bare `"Sample"` with empty groups, and SpectroMine's equivalent are the
+    reliable, greppable tells — they look like data and are not.
+  - `unclear` when the sources have not been checked, rather than checked and empty.
+  A `no` does **not** change `label`: the study is still SCP and still `include`.
 - `acquisition` — `DDA`, `DIA`, or both. Determines the acquisition-method template.
 - `instrument` — instrument as reported (e.g. `Orbitrap Eclipse`, `timsTOF SCP`).
   Verbatim; OLS/MS-ontology mapping happens during annotation.
@@ -77,3 +94,17 @@ by evidence. Keep values short and analysis-ready.
 - SCP is a young field: most datasets are post-2019. Do not exclude on date alone.
 - `carrier_channel` and `n_single_cells` are the two fields most often wrong when
   inferred from the abstract. Take them from Methods or mark `unclear`.
+- **Relevance and annotatability are different questions.** A study can be
+  unambiguously SCP and still impossible to turn into a correct SDRF, because the
+  deposited data never records which channel held which cell. `channel_map` carries
+  that; the inclusion rules do not. PXD043473 ("Toward Single Bacterium Proteomics",
+  PMID:37713396) is the reference case: a correct `include` — FACS-sorted single
+  *E. coli* with a 250-cell carrier — whose 16 files × 10 channels are
+  unannotatable, because the Methods give the run composition (3 single + 3 double
+  + 2 carrier + 2 unused) but never the channel assignment, both Percolator result
+  tables name all 11 channels `"Sample, n/a"`, the PRIDE file list holds no sample
+  sheet, and the Europe PMC supplementary is 8 figures. Screening it as
+  `channel_map=no` up front saves a full PRIDE + full-text + result-table round
+  trip in annotation before the same blocker surfaces.
+- `carrier_channel=yes` is a strong prompt to check `channel_map`: the carrier is
+  itself a channel, so "which channel is the carrier" has to be answerable too.

--- a/skills/sdrf-metascreen/SKILL.md
+++ b/skills/sdrf-metascreen/SKILL.md
@@ -306,6 +306,28 @@ Extract fields for `exclude` rows too when the evidence is already in hand — i
 costs nothing and makes the exclusion tally analysable. Never fetch extra
 publications just to fill fields on an excluded row.
 
+### 3.4b Feasibility fields are not inclusion criteria
+
+Some extract fields describe whether the study **can be used downstream**, not
+whether it belongs in the set: whether a multiplexed study records which label
+channel held which sample, whether per-sample metadata exists at row resolution,
+whether the raw files are actually deposited. Two rules:
+
+- **Never let a feasibility field move `label`.** A study that is squarely in
+  scope but impossible to annotate is still `include` — demoting it to `exclude`
+  or `uncertain` corrupts what those labels mean and hides it from the tally it
+  belongs in. Record the blocker in its own column and let the caller filter.
+- **Decide it from evidence already in hand.** These fields are cheap: the
+  screen has already opened the repository record and, for multiplexed
+  candidates, often the result tables. Do not spend extra fetches on them beyond
+  `dig_passes`.
+
+The tells are worth knowing because they *look* like data. For a
+channel→sample map, Proteome Discoverer writes every channel as `"Sample, n/a"`
+and `StudyInformation.txt` as a bare `"Sample"` with empty groups; SpectroMine
+does the same. A generic placeholder repeated across all channels of all files
+means **no map**, not a map you failed to read.
+
 ### 3.5 Dig deeper before settling for uncertain or unclear
 
 Applies only when the row so far has `label: uncertain` or at least one
@@ -441,5 +463,9 @@ each, so a human knows what to go find.
   present in an existing output file are resumed, not skipped.)
 - `unclear` (extract fields) and `uncertain` (label) are not interchangeable, and
   neither is an SDRF reserved word. This skill emits a curation TSV, not an SDRF.
+  In particular, never write `not applicable` or `not available` in this TSV, even
+  for a field whose question genuinely does not arise for a row — give that case
+  its own vocabulary word (see `channel_map` in
+  `criteria/single_cell_proteomics.md`, which uses `label free`).
 - Do not run `sdrf:annotate`, `sdrf:validate`, `sdrf:fix`, or `sdrf:improve` here.
   Those belong to `sdrf:autoresearch`.


### PR DESCRIPTION
Closes #31.

## Gap

`sdrf-metascreen` decides whether a study **is** single-cell proteomics. It had no notion of whether the study **can be annotated**. For multiplexed studies those come apart: PXD043473 is a correct `include` — FACS-sorted single *E. coli* with a 250-cell carrier — whose 16 files × 10 channels have no recoverable channel assignment anywhere, so the SDRF would mean fabricating 160 sample identities. `sdrf-annotate` refuses it correctly, but only *after* a full PRIDE + full-text + two result-table round trip. Of the 70 `include` rows in the reference screen, 14 had `carrier_channel=yes` and 17 used isobaric labelling — all exposed to the same waste.

## Changes

**`criteria/single_cell_proteomics.md`** — the issue's preferred Option 1:

- New **`channel_map`** extract field (`yes` / `no` / `label free` / `unclear`) placed next to `carrier_channel`, with what counts as a real map (deposited sample sheet, per-channel names in the result tables, an explicit channel table in the paper/SI, or layout files in an external repo cited in Data Availability), and the placeholder tells that *look* like a map: PD's per-channel `"Sample, n/a"`, `StudyInformation.txt`'s bare `"Sample"` with empty groups, SpectroMine's equivalent.
- `unclear` is reserved for "not checked", distinct from `no` = "checked and empty".
- Explicit: **a `no` does not change `label`** — this is the issue's Option 3, kept as a rule rather than left implicit.
- Notes gain the relevance-vs-annotatability distinction, PXD043473 written up as the reference case with each source that was exhausted, and `carrier_channel=yes` as the prompt to check `channel_map` (the carrier is itself a channel, so "which channel is the carrier" must be answerable too).

**`skills/sdrf-metascreen/SKILL.md`** — the skill is deliberately question-agnostic ("the criteria and the extract fields come from the user, not from this file"), so it gets the general rule rather than SCP specifics:

- New **§3.4b "Feasibility fields are not inclusion criteria"**: never let a feasibility field move `label` (demoting corrupts what `exclude`/`uncertain` mean and hides the study from its own tally), and decide such fields from evidence already in hand rather than extra fetches. The PD/SpectroMine placeholder tells are given as the worked example, since they generalize past SCP.
- Notes: never write `not applicable`/`not available` in this TSV, even for a question that genuinely does not arise for a row — give that case its own vocabulary word.

## One deviation from the issue

The issue proposed `not applicable` for the label-free case. This uses **`label free`** instead: metascreen emits a curation TSV, not an SDRF, and the repo's invariants forbid the SDRF reserved words there (`CLAUDE.md` invariant 3 — metascreen "uses **neither** reserved word"). `label free` also matches the vocabulary the adjacent `labelling` field already uses, so the two read consistently. Everything else follows Option 1 as filed.

## Scope

Docs/criteria only, no code. Neither `skills/**` nor `criteria/**` is in the CI path filter; suite run locally anyway: **243 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw)_