### PR TITLE
feat(mcp): add search_extensive — multi-keyword sweep with visible truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,9 @@ copy and the others desync silently.
 ## MCP
 
 `.mcp.json` wires the bundled `mcp/server.py` (FastMCP, name `sdrf-pride-pmc`) as a project MCP server,
-launched via `./.venv/bin/python`. It exposes 10 tools: `search_projects`, `get_project_details`,
-`get_project_files`, `get_article_metadata`, `get_pdf_by_unpaywall`, `search`, `searchClasses`,
-`getChildren`, `get_full_text_article`, `get_full_text_section`. `fastmcp`/`httpx` are in `requirements.txt` and
+launched via `./.venv/bin/python`. It exposes 11 tools: `search_projects`, `search_extensive`,
+`get_project_details`, `get_project_files`, `get_article_metadata`, `get_pdf_by_unpaywall`, `search`,
+`searchClasses`, `getChildren`, `get_full_text_article`, `get_full_text_section`. `fastmcp`/`httpx` are in `requirements.txt` and
 `environment.yml`. **The server depends on `.venv/` existing** (`uv venv .venv && uv pip install
 --python .venv/bin/python -r requirements.txt`); conda users must repoint `command` in `.mcp.json`.
 
@@ -124,6 +124,18 @@ Skills still call **five tools that exist in no bundled server** — `searchClas
 `listEmbeddingModels`, `searchWithEmbeddingModel` (in `sdrf-terms` and `sdrf-annotate`), and
 `search_articles` / `search_preprints` (in `sdrf-brainstorm`). Those paths need an external OLS/PubMed/
 bioRxiv MCP or a rewrite onto `searchClasses`/`getChildren`.
+
+**`search_projects` is one page; `search_extensive` is the whole sweep.** The latter takes a LIST of
+keywords, pages each to a short page, unions and dedupes on `all_accessions`, and reports what each
+keyword contributed (`per_keyword.new` = 0 means that keyword was redundant). PRIDE ANDs the terms in
+a keyword and then RANKS rather than filters, so recall — not pagination — is the binding limit: a
+16-keyword single-cell sweep unions to more datasets than `single-cell proteomics` returns alone
+(measured today: `nanoPOTS` 11 + `proteoCHIP` 11 = 22 unique, zero overlap). Exhaustion is proven
+ONLY by a short page; an empty page after a full one is ambiguous, so it triggers a year-partitioned
+(`filter=submissionDate==YYYY`) retry and anything still unresolved lands in `truncated` rather than
+being reported as complete. PRIDE's historical bare-keyword 100-cap (#28) no longer reproduces —
+verified 2026-08-19, v2 and v3 both paginate — which is why the partitioning is a detector, not an
+unconditional workaround.
 
 **Article identifiers must be BARE — silent-corruption class.** `get_article_metadata` and
 `get_pdf_by_unpaywall` classify with `_classify_article_id` / `_parse_identifier`, which accept a bare

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -14,6 +14,7 @@ import re
 import threading
 import urllib.parse
 import xml.etree.ElementTree as ET
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -319,26 +320,13 @@ def search_projects(
     results: list[dict] = []
     errors: list[str] = []
 
-    def _names(rec: dict, key: str) -> list[str]:
-        # /search/projects returns plain strings where /projects/{acc} returns
-        # CvParam dicts for the same logical field. Accept both.
-        out = []
-        for v in rec.get(key, []) or []:
-            out.append(v.get("name", "") if isinstance(v, dict) else str(v))
-        return out
+    _names = _pride_names
 
     if repo in {"all", "pride"}:
-        data = _cached_get_json(
-            f"{PRIDE_BASE}/search/projects",
-            params={"keyword": keyword, "pageSize": str(page_size), "page": str(page)},
-        )
-        if data is None:
+        items = _pride_search_page(keyword, page, page_size)
+        if items is None:
             errors.append("PRIDE search unreachable")
             items = []
-        else:
-            items = data if isinstance(data, list) else (
-                data.get("_embedded", {}).get("compactprojects", []) or []
-            )
         for it in items:
             results.append(_pride_search_hit(it, _names))
 
@@ -377,6 +365,242 @@ def search_projects(
         "count": len(results),
         "results": results,
     }
+    if errors:
+        out["errors"] = errors
+    return out
+
+
+def _pride_names(rec: dict, key: str) -> list[str]:
+    """/search/projects returns plain strings where /projects/{acc} returns CvParam dicts."""
+    out = []
+    for v in rec.get(key, []) or []:
+        out.append(v.get("name", "") if isinstance(v, dict) else str(v))
+    return out
+
+
+def _pride_search_page(
+    keyword: str, page: int, page_size: int, year: int | None = None
+) -> list | None:
+    """One page of PRIDE /search/projects. None means the request failed."""
+    params = {"keyword": keyword, "pageSize": str(page_size), "page": str(page)}
+    if year is not None:
+        # field==value is the documented filter grammar (pridepy --filters).
+        params["filter"] = f"submissionDate=={year}"
+    data = _cached_get_json(f"{PRIDE_BASE}/search/projects", params=params)
+    if data is None:
+        return None
+    if isinstance(data, list):
+        return data
+    return data.get("_embedded", {}).get("compactprojects", []) or []
+
+
+# A keyword search that ends on a page boundary is ambiguous: the result set may
+# be exhausted, or the endpoint may be refusing to serve past a cap. PRIDE has
+# historically done the latter (a bare keyword capped at 100 while reporting an
+# empty next page — indistinguishable from exhaustion, see #28). It paginates
+# correctly today, so this is not worked around unconditionally; it is DETECTED,
+# and the year-partitioned retry runs only when detection fires.
+_PRIDE_MAX_PAGES = 200
+_PRIDE_FIRST_YEAR = 2004
+
+
+def _pride_walk(
+    keyword: str,
+    page_size: int,
+    year: int | None = None,
+    max_results: int = 10000,
+) -> tuple[list[dict], str]:
+    """Page one PRIDE query to exhaustion.
+
+    Returns (hits, status) where status is one of:
+      exhausted      — a short page ended it; the result set is complete
+      suspected_cap  — the last full page was followed by an empty one, so
+                       "complete" cannot be distinguished from "truncated"
+      page_error     — a page request failed; the result set is INCOMPLETE
+      max_results    — the caller's ceiling stopped the walk
+    """
+    hits: list[dict] = []
+    for page in range(_PRIDE_MAX_PAGES):
+        items = _pride_search_page(keyword, page, page_size, year)
+        if items is None:
+            return hits, "page_error"
+        if not items:
+            # An empty FIRST page is a genuinely empty result set. An empty page
+            # after a full one is the ambiguous case: exhaustion and a refusal to
+            # serve past a cap look identical from here.
+            return hits, "suspected_cap" if hits else "exhausted"
+        hits.extend(items)
+        if len(items) < page_size:
+            return hits, "exhausted"
+        if len(hits) >= max_results:
+            return hits, "max_results"
+    return hits, "suspected_cap"
+
+
+def _pride_walk_partitioned(
+    keyword: str, page_size: int, max_results: int, until_year: int
+) -> tuple[list[dict], list[str]]:
+    """Re-run a capped keyword one submission year at a time.
+
+    A filter makes the endpoint paginate past the cap even when a bare keyword
+    will not, so partitioning recovers what the plain walk could not reach.
+    """
+    hits: list[dict] = []
+    still_capped: list[str] = []
+    for year in range(until_year, _PRIDE_FIRST_YEAR - 1, -1):
+        part, status = _pride_walk(keyword, page_size, year=year,
+                                   max_results=max_results - len(hits))
+        hits.extend(part)
+        if status in ("suspected_cap", "page_error", "max_results"):
+            still_capped.append(f"{keyword}@{year}:{status}")
+        if len(hits) >= max_results:
+            break
+    return hits, still_capped
+
+
+def _massive_walk(keyword: str, page_size: int, max_results: int) -> tuple[list[dict], str]:
+    """Page MassIVE PROXI to exhaustion. pageNumber is 1-based; 404 = exhausted."""
+    hits: list[dict] = []
+    for page in range(_PRIDE_MAX_PAGES):
+        data = _cached_get_json(
+            f"{MASSIVE_BASE}/datasets",
+            params={
+                "resultType": "full",
+                "search": keyword,
+                "pageSize": str(page_size),
+                "pageNumber": str(page + 1),
+            },
+            not_found_ok=True,
+        )
+        if data is None:
+            return hits, "page_error"
+        items = data if isinstance(data, list) else []
+        hits.extend(items)
+        if len(items) < page_size:
+            return hits, "exhausted"
+        if len(hits) >= max_results:
+            return hits, "max_results"
+    return hits, "suspected_cap"
+
+
+# --- 1.0b Multi-keyword exhaustive discovery ---
+@mcp.tool()
+def search_extensive(
+    keywords: list[str] | str,
+    repository: str = "all",
+    page_size: int = 100,
+    max_results: int = 5000,
+) -> dict:
+    """
+    Discover datasets across PRIDE + MassIVE by sweeping SEVERAL keywords and
+    unioning the results. Use this, not repeated search_projects calls, whenever
+    the target is a whole category ("all single-cell proteomics datasets") and
+    completeness matters.
+
+    Two measured facts drive this tool:
+
+    1. **One keyword under-recalls.** PRIDE ANDs the terms in a keyword and then
+       RANKS rather than filters, so a category sentence collapses recall
+       ("metaproteomics" 100+, "human gut metaproteomics" 2) and no single term
+       covers a field: a 16-keyword single-cell sweep (SCoPE2, nanoPOTS, plexDIA,
+       CellenONE, proteoCHIP, …) unions to more datasets than "single-cell
+       proteomics" returns on its own. Pass the sweep, not the sentence.
+    2. **Truncation must never be silent.** Each keyword is paged to a SHORT page,
+       which is the only unambiguous end-of-results signal. If a full page is
+       followed by an empty one — historically how PRIDE served a capped query —
+       the walk is retried partitioned by submission year, and anything still
+       unresolved is reported in `truncated` rather than passed off as complete.
+
+    `keywords` accepts a list or a single string. `repository`: "all" (default),
+    "pride", or "massive". `max_results` caps the union (reported when it bites).
+
+    Returns {keywords, repository, count, results:[<same hit shape as
+    search_projects>], per_keyword:{kw:{hits, new, status}}, truncated:[...],
+    errors:[...], requests_note}.
+    """
+    repo = (repository or "all").lower().strip()
+    if repo not in {"all", "pride", "massive"}:
+        return {"keywords": keywords, "count": 0, "results": [],
+                "error": f"repository must be all|pride|massive, got {repository!r}"}
+
+    if isinstance(keywords, str):
+        kws = [keywords]
+    else:
+        kws = list(keywords or [])
+    kws = [k.strip() for k in kws if k and k.strip()]
+    if not kws:
+        return {"keywords": [], "count": 0, "results": [],
+                "error": "keywords must contain at least one non-empty term"}
+
+    until_year = date.today().year
+    results: list[dict] = []
+    seen: set[str] = set()
+    per_keyword: dict[str, dict] = {}
+    truncated: list[str] = []
+    errors: list[str] = []
+
+    def _add(hit: dict) -> bool:
+        accs = [a for a in hit["all_accessions"] if a]
+        if any(a in seen for a in accs):
+            return False
+        results.append(hit)
+        seen.update(accs)
+        return True
+
+    for kw in kws:
+        stats = {"hits": 0, "new": 0, "status": "exhausted"}
+
+        if repo in {"all", "pride"}:
+            raw, status = _pride_walk(kw, page_size, max_results=max_results)
+            if status == "suspected_cap":
+                extra, still = _pride_walk_partitioned(
+                    kw, page_size, max_results, until_year)
+                raw = raw + extra
+                status = "partitioned" if not still else "truncated"
+                truncated.extend(still)
+            if status == "page_error":
+                errors.append(
+                    f"PRIDE search for {kw!r} lost a page — results are INCOMPLETE, retry")
+            if status == "max_results":
+                truncated.append(f"{kw}:max_results")
+            stats["status"] = status
+            for it in raw:
+                stats["hits"] += 1
+                if _add(_pride_search_hit(it, _pride_names)):
+                    stats["new"] += 1
+
+        if repo in {"all", "massive"}:
+            mraw, mstatus = _massive_walk(kw, page_size, max_results)
+            if mstatus == "page_error":
+                errors.append(
+                    f"MassIVE search for {kw!r} lost a page — results are INCOMPLETE, retry")
+            elif mstatus in ("suspected_cap", "max_results"):
+                truncated.append(f"{kw}@massive:{mstatus}")
+            stats["status"] = f"{stats['status']}/{mstatus}" if repo == "all" else mstatus
+            for rec in mraw:
+                stats["hits"] += 1
+                if _add(_massive_search_hit(rec)):
+                    stats["new"] += 1
+
+        per_keyword[kw] = stats
+
+    out = {
+        "keywords": kws,
+        "repository": repo,
+        "count": len(results),
+        "results": results,
+        "per_keyword": per_keyword,
+        "requests_note": (
+            "per_keyword.new is what each keyword contributed that no earlier "
+            "keyword had; a keyword with new=0 is redundant for this sweep"
+        ),
+    }
+    if truncated:
+        out["truncated"] = truncated
+        out["warning"] = (
+            "Coverage is NOT complete for the entries in `truncated` — report "
+            "them rather than presenting this union as the full result set."
+        )
     if errors:
         out["errors"] = errors
     return out

--- a/skills/sdrf-brainstorm/SKILL.md
+++ b/skills/sdrf-brainstorm/SKILL.md
@@ -55,8 +55,9 @@ Read `spec/sdrf-proteomics/TERMS.tsv` and filter by the selected template names 
 Find reference datasets to learn from:
 
 ```text
-Search PRIDE for similar experiments:
-  mcp PRIDE → search_extensive(query="<keywords>")
+Search PRIDE + MassIVE for similar experiments (sweep several SHORT keywords —
+one keyword under-recalls, and this tool unions them and reports what each added):
+  mcp PRIDE → search_extensive(keywords=["<kw1>", "<kw2>", ...])
 
 Search publications for standard experimental designs:
   mcp PubMed → search_articles(query="<keywords> AND proteomics")

--- a/skills/sdrf-metascreen/SKILL.md
+++ b/skills/sdrf-metascreen/SKILL.md
@@ -122,20 +122,40 @@ asks; otherwise deduplicate and report the number removed.
 ### Category discovery
 For `all <category> datasets`:
 
-1. **Break the category into SHORT keywords.** PRIDE ANDs the terms in a
-   keyword, so a whole category sentence collapses recall — measured:
-   `metaproteomics` returns 100+ hits, `human gut metaproteomics` returns 2.
-   Issue several short searches and union the accessions.
+1. **Break the category into SHORT keywords and sweep them.** PRIDE ANDs the
+   terms in a keyword and then RANKS rather than filters, so a whole category
+   sentence collapses recall — measured: `metaproteomics` returns 100+ hits,
+   `human gut metaproteomics` returns 2. And no single term covers a field:
+   `nanoPOTS` (11) and `proteoCHIP` (11) union to 22 single-cell datasets with
+   zero overlap, and neither term is returned by `single-cell proteomics`.
+
+```text
+Tool: search_extensive(keywords=["metaproteomics", "gut microbiome proteomics", ...])
+```
+
+   `search_extensive` pages every keyword to exhaustion, unions and dedupes on
+   `all_accessions`, and reports `per_keyword.new` — what each keyword
+   contributed that no earlier one had. A keyword with `new: 0` was redundant
+   for this sweep; put the whole `per_keyword` block in the run log, since it is
+   the evidence that the sweep was wide enough.
+
+   Use `search_projects` for a single probe or a manual page walk:
 
 ```text
 Tool: search_projects(keyword="metaproteomics", page_size=100, page=0)
 ```
 
-2. **Page until exhausted.** A call returning exactly `page_size` hits means
-   there are probably more; increment `page` until a call returns fewer.
-   If a page comes back with an `errors` entry, that page was **lost, not
-   empty** — the result set is incomplete. Retry it, and if it still fails, say
-   so in the run log rather than reporting the screen as complete.
+2. **Never report a truncated sweep as complete.** Exhaustion is proven ONLY by
+   a page shorter than `page_size`. `search_extensive` enforces that: an empty
+   page after a full one is ambiguous (PRIDE has historically capped a bare
+   keyword and served an empty next page, indistinguishable from the end), so it
+   retries partitioned by submission year and reports whatever is still
+   unresolved in `truncated`.
+   - `truncated` non-empty → the union is a **floor, not the result set**. Say so
+     in the run log and in the final report.
+   - `errors` non-empty → that page was **lost, not empty**. Retry it, and if it
+     still fails, log it rather than reporting the screen as complete.
+   If you page manually with `search_projects`, apply the same rule by hand.
 
 3. **Fast pre-filter on the structured fields the criteria constrain** — before
    fetching any publication, discard obvious mismatches. `search_projects`
@@ -396,6 +416,9 @@ include         : N  (PRIDE N, MassIVE N)
 exclude         : N
 uncertain       : N
 lost_pages      : <none | the search pages that errored and stayed incomplete>
+truncated       : <none | the search_extensive `truncated` entries — for each one
+                  listed, coverage is a floor, not a complete set>
+per_keyword     : <the search_extensive per_keyword block: hits / new per keyword>
 exclusions_by_criterion:
   rule 2 (Orbitrap instrument) : N
   rule 3 (DDA acquisition)     : N

--- a/tests/test_mcp_pride.py
+++ b/tests/test_mcp_pride.py
@@ -283,3 +283,98 @@ def test_cached_get_json_404_is_not_found_not_failure(monkeypatch):
     assert server._cached_get_json("https://example.invalid/y") is None
     server._json_cache.clear()
     assert server._cached_get_json("https://example.invalid/y", not_found_ok=True) == []
+
+
+# --- search_extensive: multi-keyword union + visible truncation ---------
+
+def _pride_pages(pages: dict):
+    """Fake _cached_get_json serving PRIDE pages keyed by (keyword, filter, page)."""
+    def fake(url, params=None, **kw):
+        params = params or {}
+        if "pride" not in url:
+            return []          # MassIVE: exhausted immediately
+        key = (params.get("keyword"), params.get("filter"), params.get("page"))
+        return pages.get(key, [])
+    return fake
+
+
+def _accs(n, start=1):
+    return [{"accession": f"PXD{i:06d}"} for i in range(start, start + n)]
+
+
+def test_search_extensive_unions_keywords_and_dedupes(monkeypatch):
+    """Recall needs a keyword sweep; the same dataset found twice is one row."""
+    monkeypatch.setattr(server, "_cached_get_json", _pride_pages({
+        ("SCoPE2", None, "0"): _accs(2, 1),          # PXD000001, PXD000002
+        ("nanoPOTS", None, "0"): _accs(2, 2),        # PXD000002 again, PXD000003
+    }))
+    r = server.search_extensive(["SCoPE2", "nanoPOTS"], page_size=100)
+    assert r["count"] == 3
+    assert r["per_keyword"]["SCoPE2"]["new"] == 2
+    assert r["per_keyword"]["nanoPOTS"]["new"] == 1   # the overlap is not double counted
+    assert "truncated" not in r
+
+
+def test_search_extensive_accepts_a_single_string(monkeypatch):
+    monkeypatch.setattr(server, "_cached_get_json", _pride_pages({
+        ("plexDIA", None, "0"): _accs(1),
+    }))
+    assert server.search_extensive("plexDIA")["count"] == 1
+
+
+def test_search_extensive_pages_until_a_short_page(monkeypatch):
+    """A full page is never the end: only a short page proves exhaustion."""
+    monkeypatch.setattr(server, "_cached_get_json", _pride_pages({
+        ("proteomics", None, "0"): _accs(2, 1),
+        ("proteomics", None, "1"): _accs(2, 3),
+        ("proteomics", None, "2"): _accs(1, 5),
+    }))
+    r = server.search_extensive("proteomics", page_size=2)
+    assert r["count"] == 5
+    assert r["per_keyword"]["proteomics"]["status"].startswith("exhausted")
+    # Every page is fetched once: a re-read page would inflate `hits` past `count`.
+    assert r["per_keyword"]["proteomics"]["hits"] == 5
+
+
+def test_full_page_then_empty_page_triggers_partitioned_retry(monkeypatch):
+    """The historical PRIDE cap (#28): a full page then an empty one is ambiguous.
+
+    It must not be reported as exhaustion. The year-partitioned retry recovers
+    the records the plain walk could not reach.
+    """
+    year = server.date.today().year
+    monkeypatch.setattr(server, "_cached_get_json", _pride_pages({
+        ("proteomics", None, "0"): _accs(2, 1),
+        ("proteomics", None, "1"): [],                       # looks like the end
+        ("proteomics", f"submissionDate=={year}", "0"): _accs(1, 3),
+    }))
+    r = server.search_extensive("proteomics", page_size=2)
+    assert r["per_keyword"]["proteomics"]["status"].startswith("partitioned")
+    assert r["count"] == 3                                   # PXD000003 recovered
+    assert "truncated" not in r
+
+
+def test_a_partition_still_capped_is_reported_not_swallowed(monkeypatch):
+    year = server.date.today().year
+    monkeypatch.setattr(server, "_cached_get_json", _pride_pages({
+        ("proteomics", None, "0"): _accs(2, 1),
+        ("proteomics", None, "1"): [],
+        ("proteomics", f"submissionDate=={year}", "0"): _accs(2, 3),
+        ("proteomics", f"submissionDate=={year}", "1"): [],   # capped again
+    }))
+    r = server.search_extensive("proteomics", page_size=2)
+    assert any(f"@{year}:suspected_cap" in t for t in r["truncated"])
+    assert "NOT complete" in r["warning"]
+
+
+def test_search_extensive_reports_a_lost_page_as_incomplete(monkeypatch):
+    def fake(url, params=None, **kw):
+        return None if "pride" in url else []
+    monkeypatch.setattr(server, "_cached_get_json", fake)
+    r = server.search_extensive("proteomics")
+    assert any("INCOMPLETE" in e for e in r["errors"])
+
+
+def test_search_extensive_rejects_empty_and_bad_input():
+    assert "error" in server.search_extensive([])
+    assert "error" in server.search_extensive(["x"], repository="nope")


### PR DESCRIPTION
Closes #28.

## What is still true, and what isn't

Two of the issue's three findings are live; the headline one is not, so this PR does **not** implement the workaround it proposed.

**Verified against the live API today (2026-08-19):**

| Issue's claim (2026-07-15) | Today |
|---|---|
| Bare keyword caps at 100; `page=1` returns `[]` | **No longer reproduces.** `keyword=proteomics` returns 600 unique accessions across pages 0–5 on **both** v2 and v3, no empty page |
| `single-cell proteomics` = exactly 100 | 105, ending on a **short page** (page 1 returns 5) — a genuine exhaustion signal |
| Single-keyword recall under-covers the field | **Still true.** `nanoPOTS` (11) + `proteoCHIP` (11) = 22 unique, zero overlap, and neither is returned by `single-cell proteomics` |
| No tool unions keywords; `sdrf-brainstorm:59` calls `search_extensive(query=…)`, which exists nowhere | **Still true** — this is what the PR fixes |

So the binding limit is **recall, not pagination**, exactly as the issue's own "second-order finding" says. Hard-coding year-partitioning for every query would spend ~23 requests per keyword working around a server bug that PRIDE has since fixed.

## What this adds

**`mcp/server.py` — `search_extensive(keywords, repository="all", page_size=100, max_results=5000)`**

- Takes a **list** of keywords (or a single string), pages each to exhaustion, unions and dedupes on `all_accessions` preferring the richer PRIDE record over the MassIVE one, and returns the same hit shape as `search_projects`.
- Reports `per_keyword: {hits, new, status}` — `new` is what that keyword contributed that no earlier one had, so a redundant keyword shows up as `new: 0` and a sweep can be justified rather than asserted. This is the "no silent caps" principle the issue asks for.
- **Truncation is detected, not assumed.** Exhaustion is proven only by a page shorter than `page_size`. An empty page after a full one is the ambiguous shape the issue documented (cap vs end), so it triggers a year-partitioned retry (`filter=submissionDate==YYYY`, the syntax the issue verified), and anything still unresolved lands in `truncated` alongside a `warning` that the union is a floor. A failed page is reported as `INCOMPLETE`, never as the end.
- Extracted `_pride_names` / `_pride_search_page` and reused them from `search_projects`, so the request spelling lives in one place rather than drifting between the two tools.

**Skills / docs**

- `skills/sdrf-brainstorm/SKILL.md` — calls the real signature instead of the phantom `search_extensive(query=…)`.
- `skills/sdrf-metascreen/SKILL.md` — Step 2 category discovery now uses `search_extensive` (with `search_projects` kept for a single probe or manual page walk), and step 2's second rule is now "never report a truncated sweep as complete", with `truncated` and `per_keyword` added to the Step 5 run log.
- `CLAUDE.md` — 11 tools, and a paragraph on the `search_projects` vs `search_extensive` split including the measured recall numbers and the note that the 100-cap no longer reproduces.

## Tests

7 new in `tests/test_mcp_pride.py`, all offline: union + dedupe across keywords, the single-string form, paging to a short page **without re-reading a page** (`hits == count` guards against a look-ahead double count), the full-page-then-empty partitioned retry recovering records, a partition that is *still* capped being surfaced in `truncated`, a lost page reported as incomplete, and input validation.

Full suite: **250 passed** (243 before). `ruff check mcp/ tests/test_mcp_pride.py` clean.

Live smoke check of the new tool: `search_extensive(["nanoPOTS", "proteoCHIP"], repository="pride")` → 22 unique, `per_keyword` 11/11 new each, no `truncated`, no `errors`.

## Out of scope

The upstream `pridepy` note at the end of the issue is a different repo and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw)_