### PR TITLE
feat(tools): read Bruker DIA isolation windows from analysis.tdf over HTTP range

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -49,6 +49,7 @@ jobs:
           python -m tools massive-files --help
           python -m tools verify --help
           python -m tools cellline --help
+          python -m tools bruker-dia --help
 
       - name: Run offline hallucination check on synthetic example
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ git submodule update --init --recursive     # restore pinned state (what you usu
 git submodule update --remote --recursive   # advance to upstream tip; leaves a dirty gitlink
 
 # tools CLI (no console_scripts; requires cwd == repo root)
-python -m tools --help   # check, score, fix, benchmark, massive-files, verify, cellline, review-gate
+python -m tools --help   # check, score, fix, benchmark, massive-files, verify, cellline,
+                         # review-gate, audit-existing, bruker-dia
 ```
 
 `python` is an alias to `python3` here, not a binary — skills invoke bare `python`, assuming an

--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -747,6 +747,19 @@ techsdrf can detect discrepancies between what's declared in the paper/PRIDE and
 what's actually in the raw data — especially for instrument model specificity,
 mass tolerances, and undeclared or incorrect modifications.
 
+**Bruker timsTOF / diaPASEF — the DIA windows are readable without any of that.**
+`analysis.tdf` inside a `.d` archive is a SQLite database, so one member of the ZIP
+can be range-fetched (14.7 MB rather than a 2.5 GB download) and read directly:
+```bash
+python -m tools bruker-dia "<url of the .d.zip>"
+```
+It reports the isolation windows, m/z coverage and CE ramp. Fill
+`comment[isolation window width]` from it and **only** from it: diaPASEF windows are
+variable-width, the column is a single scalar, and deriving one from the manuscript
+("15 windows spanning 400–1000" → 40) yields a width matching no actual window while
+passing both the regex and `parse_sdrf`. When the widths vary, the honest value is
+`not available` with the measured table in the report — see `/sdrf:techrefine`.
+
 ## Step 6: Map Files to Samples
 
 - Get file names from Step 1.2 (PRIDE file list)

--- a/skills/sdrf-techrefine/SKILL.md
+++ b/skills/sdrf-techrefine/SKILL.md
@@ -33,6 +33,9 @@ pip install techsdrf
   # Check availability:
   msconvert --help
   ```
+  For Bruker DIA **isolation windows** specifically, no converter and no download
+  are needed — `python -m tools bruker-dia` range-reads `analysis.tdf` out of the
+  archive. See the Bruker section below.
 
 If converters are missing, inform the user which file types cannot be processed
 and suggest installation commands. techsdrf will skip files it cannot convert.
@@ -250,6 +253,50 @@ If this is a ProteomeXchange dataset:
 Your refined SDRF has verified technical metadata from actual raw file analysis.
 Run /sdrf:contribute to submit this annotation to the community repository.
 ```
+
+## Bruker timsTOF: DIA windows straight from `analysis.tdf`
+
+techsdrf needs the raw files converted; for **one** high-value table on Bruker
+`.d` data it is not needed at all, and neither is the download. `analysis.tdf`
+inside a `.d` archive is a plain SQLite database, and PRIDE's HTTPS mirror
+serves byte ranges — so the ZIP central directory can be read from the tail and
+that single member range-fetched. Measured on `PXD052416`: **14.7 MB instead of
+2502 MB**, a ~170x reduction.
+
+```bash
+python -m tools bruker-dia "https://ftp.pride.ebi.ac.uk/.../Blank_BK1_1_1799.d.zip"
+python -m tools bruker-dia path/to/analysis.tdf --json     # already extracted
+```
+
+It reads `DiaFrameMsMsWindows` and reports the isolation windows, the measured
+m/z coverage, the collision-energy ramp, and the instrument name from
+`GlobalMetadata`. Use it whenever the deposition is timsTOF/diaPASEF and the
+manuscript is vague about window placement — on PXD052416 the paper puts the
+placement in a supplementary *figure*, i.e. unreadable, while the table has the
+numbers.
+
+### The isolation-window trap — read this before filling the column
+
+`comment[isolation window width]` is a **single scalar** (`pattern:
+^\d+(\.\d+)?$`, examples 25/8/4). That fits uniform SWATH-style windows.
+diaPASEF windows are variable-width by design — 15 distinct widths from 29.52 to
+74.51 m/z in PXD052416 — and **no single number is correct** for them.
+
+| Situation | What to write |
+|---|---|
+| Every window the same width | that width |
+| Widths vary (diaPASEF, typical) | `not available`, with the measured table in the report |
+
+Never derive the value from the manuscript instead: "15 windows spanning
+400–1000" → `600/15 = 40` produces a width matching **none** of the 15 actual
+windows, and it passes both the regex and `parse_sdrf`. A mean or a median is
+the same error with more arithmetic. `python -m tools bruker-dia` applies this
+rule for you and prints the value it would write plus the reason.
+
+This is a spec limitation, not an annotator failure — the column cannot express
+what the instrument did (bigbio/sdrf-templates, tracked from #33). Until it can,
+`not available` plus the measured table is the honest answer, and the table in
+the report is what makes the value recoverable later.
 
 ## What techsdrf Detects
 

--- a/tests/test_bruker_tdf.py
+++ b/tests/test_bruker_tdf.py
@@ -1,0 +1,248 @@
+"""Tests for tools.bruker_tdf — DIA windows out of a Bruker .d without downloading it.
+
+Offline: a real ZIP holding a real SQLite `analysis.tdf` is built in a tmpdir and
+read through the same Fetcher interface the HTTP path uses, so the central
+directory parse, the local-header offset arithmetic, the inflate and the SQLite
+read are all exercised for real — only the socket is absent.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import struct
+import zipfile
+
+import pytest
+
+from tools.bruker_tdf import (
+    TdfAcquisition,
+    ZipRangeError,
+    describe_isolation_window,
+    fetch_tdf,
+    file_fetcher,
+    list_zip_entries,
+    read_tdf,
+    render,
+)
+
+# The DIA windows #33 quotes VERBATIM from PXD052416 (timsTOF Ultra, diaPASEF).
+# Only these seven rows are reproduced in the issue, so only these are used as
+# real data; nothing here is back-filled with invented m/z values.
+_PXD052416_QUOTED = [
+    (1, 34, 580, 744.83, 45.10, 45.9),
+    (1, 580, 724, 572.33, 29.99, 32.8),
+    (1, 724, 944, 417.29, 34.58, 25.8),
+    (2, 34, 557, 792.64, 52.52, 46.4),
+    (5, 34, 423, 977.74, 44.53, 48.9),
+    (5, 423, 596, 703.34, 39.89, 38.2),
+    (5, 596, 944, 543.57, 29.52, 28.2),
+]
+
+# The issue also lists all 15 widths of that file. Here the widths are the real
+# measurement; the m/z and CE columns are placeholders, since the issue does not
+# quote them — this fixture exists only to exercise the 15-distinct-widths case.
+_ALL_15_WIDTHS = [
+    29.52, 29.55, 29.99, 31.49, 31.67, 33.51, 34.58, 35.07,
+    37.01, 39.89, 44.53, 45.10, 52.52, 65.06, 74.51,
+]
+_WIDTHS_ONLY = [
+    (1 + i // 3, 34, 944, 400.0 + 40 * i, w, 25.0 + i)
+    for i, w in enumerate(_ALL_15_WIDTHS)
+]
+
+
+def _make_tdf(path, windows=_PXD052416_QUOTED, with_metadata=True):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE DiaFrameMsMsWindows (WindowGroup INTEGER, ScanNumBegin INTEGER,"
+        " ScanNumEnd INTEGER, IsolationMz REAL, IsolationWidth REAL, CollisionEnergy REAL)"
+    )
+    conn.executemany("INSERT INTO DiaFrameMsMsWindows VALUES (?,?,?,?,?,?)", windows)
+    if with_metadata:
+        conn.execute("CREATE TABLE GlobalMetadata (Key TEXT, Value TEXT)")
+        conn.execute("INSERT INTO GlobalMetadata VALUES ('InstrumentName','timsTOF Ultra')")
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def d_zip(tmp_path):
+    """A .d.zip shaped like the real thing: the big binary first, the tdf inside."""
+    tdf = _make_tdf(tmp_path / "analysis.tdf")
+    z = tmp_path / "Blank_BK1_1_1799.d.zip"
+    with zipfile.ZipFile(z, "w", zipfile.ZIP_DEFLATED) as zf:
+        # incompressible, so the archive really is larger than the member
+        zf.writestr("Blank_BK1_1_1799.d/analysis.tdf_bin", os.urandom(200_000))
+        zf.write(tdf, "Blank_BK1_1_1799.d/analysis.tdf")
+        zf.writestr("Blank_BK1_1_1799.d/SampleInfo.xml", "<sample/>")
+    return z
+
+
+# --- ZIP reading --------------------------------------------------------
+
+def test_central_directory_lists_members_from_the_tail(d_zip):
+    entries = list_zip_entries(file_fetcher(d_zip), d_zip.stat().st_size)
+    assert {e.name.split("/")[-1] for e in entries} == {
+        "analysis.tdf_bin", "analysis.tdf", "SampleInfo.xml"}
+
+
+def test_extracts_only_the_tdf_member(d_zip):
+    blob = fetch_tdf(str(d_zip))
+    # SQLite's file magic — proves we inflated the right member, not the padding.
+    assert blob.startswith(b"SQLite format 3\x00")
+    assert len(blob) < d_zip.stat().st_size
+
+
+def _zip_with_divergent_extra(path, name: str, payload: bytes) -> None:
+    """Hand-roll a ZIP whose LOCAL extra field is longer than the central one.
+
+    Real writers do this (alignment padding, UT timestamps), and it is the trap
+    a range reader must not fall into: the member's data offset is
+    local_header + 30 + local_name_len + LOCAL_extra_len, and using the central
+    directory's extra length instead lands short of the stream.
+    """
+    import zlib as _zlib
+    raw_name = name.encode()
+    local_extra = struct.pack("<HH", 0xFFFF, 4) + b"pad!"     # 8 bytes, local only
+    crc = _zlib.crc32(payload)
+    local = (
+        b"PK\x03\x04" + struct.pack("<HHHHHIIIHH", 20, 0, 0, 0, 0, crc,
+                                    len(payload), len(payload),
+                                    len(raw_name), len(local_extra))
+        + raw_name + local_extra + payload
+    )
+    central = (
+        b"PK\x01\x02" + struct.pack("<HHHHHHIIIHHHHHII", 20, 20, 0, 0, 0, 0, crc,
+                                    len(payload), len(payload), len(raw_name),
+                                    0, 0, 0, 0, 0, 0)
+        + raw_name
+    )
+    eocd = b"PK\x05\x06" + struct.pack("<HHHHIIH", 0, 0, 1, 1,
+                                       len(central), len(local), 0)
+    path.write_bytes(local + central + eocd)
+
+
+def test_member_offset_comes_from_the_local_header(tmp_path):
+    """A local extra field the central directory does not know about.
+
+    If the data offset were computed from the central entry, the read would
+    start 8 bytes early and return garbage instead of the SQLite header.
+    """
+    tdf = _make_tdf(tmp_path / "analysis.tdf")
+    z = tmp_path / "divergent.zip"
+    _zip_with_divergent_extra(z, "analysis.tdf", tdf.read_bytes())
+    blob = fetch_tdf(str(z))
+    assert blob.startswith(b"SQLite format 3\x00")
+    assert read_tdf(blob).is_dia
+
+
+def test_stored_member_needs_no_inflate(tmp_path):
+    tdf = _make_tdf(tmp_path / "analysis.tdf")
+    z = tmp_path / "stored.zip"
+    with zipfile.ZipFile(z, "w", zipfile.ZIP_STORED) as zf:
+        zf.write(tdf, "analysis.tdf")
+    assert fetch_tdf(str(z)).startswith(b"SQLite format 3\x00")
+
+
+def test_missing_member_names_what_the_archive_holds(tmp_path):
+    z = tmp_path / "nope.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("analysis.tdf_bin", b"x")
+    with pytest.raises(ZipRangeError, match="analysis.tdf_bin"):
+        fetch_tdf(str(z))
+
+
+def test_not_a_zip_is_reported_not_guessed(tmp_path):
+    p = tmp_path / "junk.zip"
+    p.write_bytes(b"not a zip at all")
+    with pytest.raises(ZipRangeError, match="end-of-central-directory"):
+        fetch_tdf(str(p))
+
+
+def test_an_extracted_tdf_is_read_directly(tmp_path):
+    tdf = _make_tdf(tmp_path / "analysis.tdf")
+    assert fetch_tdf(str(tdf)).startswith(b"SQLite format 3\x00")
+
+
+# --- the tables ---------------------------------------------------------
+
+def test_reads_the_quoted_windows(d_zip):
+    acq = read_tdf(fetch_tdf(str(d_zip)), source=str(d_zip))
+    assert acq.is_dia
+    assert len(acq.windows) == len(_PXD052416_QUOTED)
+    assert {w.window_group for w in acq.windows} == {1, 2, 5}
+    assert acq.properties["InstrumentName"] == "timsTOF Ultra"
+
+
+def test_edges_are_measured_not_taken_from_the_prose(d_zip):
+    """The paper (PMID:39536954) says "400 to 1000 m/z" and a CE ramp.
+
+    The window table gives both as numbers: the edges are computed from
+    IsolationMz +/- IsolationWidth/2, and the CE range comes straight out of the
+    rows — no reading of a supplementary figure required.
+    """
+    acq = read_tdf(fetch_tdf(str(d_zip)))
+    lo, hi = acq.mz_range
+    assert (round(lo, 2), round(hi, 2)) == (400.0, 1000.0)
+    assert acq.ce_range == (25.8, 48.9)
+
+
+def test_a_tdf_without_the_window_table_is_not_dia(tmp_path):
+    p = tmp_path / "analysis.tdf"
+    conn = sqlite3.connect(p)
+    conn.execute("CREATE TABLE Frames (Id INTEGER)")
+    conn.commit()
+    conn.close()
+    acq = read_tdf(p)
+    assert not acq.is_dia
+    assert describe_isolation_window(acq)["sdrf_value"] is None
+
+
+# --- what goes in the SDRF ---------------------------------------------
+
+def test_variable_windows_refuse_a_scalar(d_zip):
+    """The whole point of #33: distinct widths, so no single number is right."""
+    d = describe_isolation_window(read_tdf(fetch_tdf(str(d_zip))))
+    assert d["sdrf_value"] == "not available"
+    assert len(d["widths"]) == len(_PXD052416_QUOTED)
+
+
+def test_all_fifteen_widths_of_the_reported_file(tmp_path):
+    d = describe_isolation_window(
+        read_tdf(_make_tdf(tmp_path / "analysis.tdf", windows=_WIDTHS_ONLY)))
+    assert d["widths"] == sorted(_ALL_15_WIDTHS)
+    assert d["sdrf_value"] == "not available"
+
+
+def test_the_tempting_wrong_derivation_is_named(tmp_path):
+    """(1000-400)/15 = 40 m/z matches no actual window, passes the regex, and
+
+    passes parse_sdrf. The rationale has to warn about it explicitly, or the
+    next annotator just recomputes it.
+    """
+    d = describe_isolation_window(
+        read_tdf(_make_tdf(tmp_path / "analysis.tdf", windows=_WIDTHS_ONLY)))
+    assert 40.0 not in d["widths"]
+    assert "mean" in d["rationale"]
+
+
+def test_uniform_windows_do_carry_a_scalar(tmp_path):
+    """SWATH-style acquisitions are exactly what the scalar column was made for."""
+    rows = [(1, 0, 100, 400.0 + 25 * i, 25.0, 30.0) for i in range(8)]
+    tdf = _make_tdf(tmp_path / "analysis.tdf", windows=rows)
+    d = describe_isolation_window(read_tdf(tdf))
+    assert d["sdrf_value"] == "25"
+    assert d["widths"] == [25.0]
+
+
+def test_render_shows_the_table_and_the_verdict(d_zip):
+    out = render(read_tdf(fetch_tdf(str(d_zip)), source="x.d.zip"))
+    assert "7 in 3 group(s)" in out
+    assert "comment[isolation window width] -> not available" in out
+    assert "744.83" in out          # a real window row, for the report
+
+
+def test_render_handles_a_non_dia_run():
+    assert "not DIA" in render(TdfAcquisition(source="s"))

--- a/tools/bruker_tdf.py
+++ b/tools/bruker_tdf.py
@@ -1,0 +1,419 @@
+"""Read Bruker timsTOF acquisition metadata out of `analysis.tdf` — over HTTP.
+
+A `.d` archive is 2.5–9.2 GB, well past any sane download budget, but the table
+that answers "what were the DIA isolation windows" is `analysis.tdf`, a plain
+SQLite database of ~15 MB sitting inside it. PRIDE's HTTPS mirror sends
+`Accept-Ranges: bytes`, so the ZIP central directory can be read from the tail
+and that one member range-fetched: 14.7 MB instead of 2502 MB on the measured
+case (PXD052416), a ~170x reduction, with no dependency beyond the stdlib.
+
+The windows matter because they are otherwise unknowable. diaPASEF windows are
+variable-width by design — 15 distinct widths from 29.52 to 74.51 m/z in that
+dataset — and the intuitive derivation from a manuscript ("15 windows spanning
+400-1000" -> 600/15 = 40) yields a number that is not one of them, passes the
+`comment[isolation window width]` regex, and passes parse_sdrf. Silent
+corruption. See `describe_isolation_window()` for what to write instead.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import struct
+import tempfile
+import urllib.request
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+USER_AGENT = "sdrf-skills/0.1 (+https://github.com/bigbio/sdrf-skills)"
+DEFAULT_TIMEOUT = 60
+
+# The member we want, and how much of the archive tail to read to find it.
+TDF_MEMBER = "analysis.tdf"
+_EOCD_SIG = b"PK\x05\x06"
+_EOCD64_LOCATOR_SIG = b"PK\x06\x07"
+_EOCD64_SIG = b"PK\x06\x06"
+_CEN_SIG = b"PK\x01\x02"
+_TAIL_BYTES = 128 * 1024
+
+# A .tdf over this size is not what we think it is; refuse rather than stream
+# gigabytes into a temp file.
+MAX_MEMBER_BYTES = 512 * 1024 * 1024
+
+
+class ZipRangeError(RuntimeError):
+    """The archive could not be read by range requests."""
+
+
+# ---------------------------------------------------------------------------
+# HTTP range reading
+# ---------------------------------------------------------------------------
+
+Fetcher = Callable[[int, int | None], bytes]
+"""fetch(start, end) -> bytes. `end` is inclusive, as in the HTTP Range header;
+`end=None` means "to the end of the file"."""
+
+
+def http_fetcher(url: str, timeout: int = DEFAULT_TIMEOUT) -> Fetcher:
+    """A Fetcher backed by HTTP range requests."""
+
+    def fetch(start: int, end: int | None = None) -> bytes:
+        rng = f"bytes={start}-" if end is None else f"bytes={start}-{end}"
+        req = urllib.request.Request(
+            url, headers={"Range": rng, "User-Agent": USER_AGENT}
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            # 206 = the server honoured the range. A 200 means it ignored it and
+            # is sending the WHOLE multi-GB archive, which is exactly what this
+            # module exists to avoid.
+            if resp.status == 200 and start > 0:
+                raise ZipRangeError(
+                    "server ignored the Range header and is sending the whole file"
+                )
+            return resp.read()
+
+    return fetch
+
+
+def file_fetcher(path: str | Path) -> Fetcher:
+    """A Fetcher backed by a local file — same code path, no network."""
+    p = Path(path)
+
+    def fetch(start: int, end: int | None = None) -> bytes:
+        with p.open("rb") as fh:
+            fh.seek(start)
+            return fh.read() if end is None else fh.read(end - start + 1)
+
+    return fetch
+
+
+def _remote_size(url: str, timeout: int = DEFAULT_TIMEOUT) -> int:
+    req = urllib.request.Request(
+        url, method="HEAD", headers={"User-Agent": USER_AGENT}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        size = resp.headers.get("Content-Length")
+        if not size:
+            raise ZipRangeError("server did not report Content-Length")
+        return int(size)
+
+
+# ---------------------------------------------------------------------------
+# ZIP central directory
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ZipEntry:
+    name: str
+    compress_type: int
+    compressed_size: int
+    uncompressed_size: int
+    header_offset: int
+
+
+def list_zip_entries(fetch: Fetcher, size: int) -> list[ZipEntry]:
+    """Parse a ZIP's central directory using only tail reads.
+
+    Handles ZIP64, which is not optional here: a `.d.zip` above 4 GB stores its
+    real central-directory offset in the ZIP64 record and leaves 0xFFFFFFFF in
+    the classic one, so a parser that ignores ZIP64 seeks to a garbage offset.
+    """
+    tail_start = max(0, size - _TAIL_BYTES)
+    tail = fetch(tail_start, size - 1)
+
+    idx = tail.rfind(_EOCD_SIG)
+    if idx < 0:
+        raise ZipRangeError("no end-of-central-directory record in the archive tail")
+    cen_size, cen_offset = struct.unpack("<II", tail[idx + 12:idx + 20])
+
+    loc = tail.rfind(_EOCD64_LOCATOR_SIG, 0, idx)
+    if loc >= 0:
+        (eocd64_offset,) = struct.unpack("<Q", tail[loc + 8:loc + 16])
+        rel = eocd64_offset - tail_start
+        if 0 <= rel < len(tail) and tail[rel:rel + 4] == _EOCD64_SIG:
+            cen_size, cen_offset = struct.unpack("<QQ", tail[rel + 40:rel + 56])
+        else:
+            head = fetch(eocd64_offset, eocd64_offset + 55)
+            if head[:4] != _EOCD64_SIG:
+                raise ZipRangeError("ZIP64 locator points at no ZIP64 EOCD record")
+            cen_size, cen_offset = struct.unpack("<QQ", head[40:56])
+
+    if cen_offset >= tail_start:
+        cen = tail[cen_offset - tail_start:cen_offset - tail_start + cen_size]
+    else:
+        cen = fetch(cen_offset, cen_offset + cen_size - 1)
+
+    entries: list[ZipEntry] = []
+    pos = 0
+    while pos + 46 <= len(cen) and cen[pos:pos + 4] == _CEN_SIG:
+        (compress_type,) = struct.unpack("<H", cen[pos + 10:pos + 12])
+        csize, usize = struct.unpack("<II", cen[pos + 20:pos + 28])
+        n_len, x_len, c_len = struct.unpack("<HHH", cen[pos + 28:pos + 34])
+        (offset,) = struct.unpack("<I", cen[pos + 42:pos + 46])
+        name = cen[pos + 46:pos + 46 + n_len].decode("utf-8", "replace")
+        extra = cen[pos + 46 + n_len:pos + 46 + n_len + x_len]
+        usize, csize, offset = _apply_zip64_extra(extra, usize, csize, offset)
+        entries.append(ZipEntry(name, compress_type, csize, usize, offset))
+        pos += 46 + n_len + x_len + c_len
+    if not entries:
+        raise ZipRangeError("central directory held no entries")
+    return entries
+
+
+def _apply_zip64_extra(
+    extra: bytes, usize: int, csize: int, offset: int
+) -> tuple[int, int, int]:
+    """Replace 0xFFFFFFFF placeholders from the ZIP64 extra field, in order."""
+    pos = 0
+    while pos + 4 <= len(extra):
+        tag, ln = struct.unpack("<HH", extra[pos:pos + 4])
+        body = extra[pos + 4:pos + 4 + ln]
+        if tag == 0x0001:
+            vals = list(struct.unpack(f"<{len(body) // 8}Q", body[:len(body) // 8 * 8]))
+            for name in ("usize", "csize", "offset"):
+                if not vals:
+                    break
+                if name == "usize" and usize == 0xFFFFFFFF:
+                    usize = vals.pop(0)
+                elif name == "csize" and csize == 0xFFFFFFFF:
+                    csize = vals.pop(0)
+                elif name == "offset" and offset == 0xFFFFFFFF:
+                    offset = vals.pop(0)
+        pos += 4 + ln
+    return usize, csize, offset
+
+
+def extract_member(fetch: Fetcher, entry: ZipEntry) -> bytes:
+    """Range-fetch and inflate one ZIP member."""
+    if entry.uncompressed_size > MAX_MEMBER_BYTES:
+        raise ZipRangeError(
+            f"{entry.name} is {entry.uncompressed_size / 1e6:.0f} MB, "
+            f"over the {MAX_MEMBER_BYTES / 1e6:.0f} MB member cap"
+        )
+    # The local header repeats the name and extra fields with its OWN lengths —
+    # they routinely differ from the central directory's, so the data offset has
+    # to be computed from the local header, never from the central one.
+    head = fetch(entry.header_offset, entry.header_offset + 29)
+    if head[:4] != b"PK\x03\x04":
+        raise ZipRangeError(f"no local file header at offset {entry.header_offset}")
+    n_len, x_len = struct.unpack("<HH", head[26:30])
+    data_start = entry.header_offset + 30 + n_len + x_len
+    raw = fetch(data_start, data_start + entry.compressed_size - 1)
+    if entry.compress_type == 0:
+        return raw
+    if entry.compress_type == 8:
+        return zlib.decompress(raw, -15)
+    raise ZipRangeError(f"unsupported compression method {entry.compress_type}")
+
+
+def fetch_tdf(source: str, member: str = TDF_MEMBER) -> bytes:
+    """Pull `analysis.tdf` out of a local or remote `.d` archive.
+
+    `source` is a URL or a path to the `.d.zip`, or to an already-extracted
+    `analysis.tdf` (returned as-is).
+    """
+    if not source.startswith(("http://", "https://")):
+        p = Path(source)
+        if p.suffix == ".tdf" or p.name == member:
+            return p.read_bytes()
+        fetch, size = file_fetcher(p), p.stat().st_size
+    else:
+        fetch, size = http_fetcher(source), _remote_size(source)
+
+    entries = list_zip_entries(fetch, size)
+    for e in entries:
+        if e.name == member or e.name.endswith("/" + member):
+            return extract_member(fetch, e)
+    raise ZipRangeError(
+        f"{member} not in the archive (members: {', '.join(e.name for e in entries[:8])})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The tables
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DiaWindow:
+    window_group: int
+    scan_begin: int
+    scan_end: int
+    isolation_mz: float
+    isolation_width: float
+    collision_energy: float
+
+    @property
+    def mz_low(self) -> float:
+        return self.isolation_mz - self.isolation_width / 2
+
+    @property
+    def mz_high(self) -> float:
+        return self.isolation_mz + self.isolation_width / 2
+
+
+@dataclass
+class TdfAcquisition:
+    windows: list[DiaWindow] = field(default_factory=list)
+    properties: dict[str, str] = field(default_factory=dict)
+    source: str = ""
+
+    @property
+    def is_dia(self) -> bool:
+        return bool(self.windows)
+
+    @property
+    def widths(self) -> list[float]:
+        return sorted({round(w.isolation_width, 4) for w in self.windows})
+
+    @property
+    def uniform_width(self) -> float | None:
+        """The single width, or None when the windows are variable-width."""
+        return self.widths[0] if len(self.widths) == 1 else None
+
+    @property
+    def mz_range(self) -> tuple[float, float] | None:
+        if not self.windows:
+            return None
+        return (
+            min(w.mz_low for w in self.windows),
+            max(w.mz_high for w in self.windows),
+        )
+
+    @property
+    def ce_range(self) -> tuple[float, float] | None:
+        if not self.windows:
+            return None
+        ces = [w.collision_energy for w in self.windows]
+        return (min(ces), max(ces))
+
+
+def read_tdf(blob: bytes | str | Path, source: str = "") -> TdfAcquisition:
+    """Read the acquisition tables out of an `analysis.tdf` SQLite database."""
+    if isinstance(blob, (str, Path)):
+        path, tmp = Path(blob), None
+    else:
+        # sqlite3 needs a file. Named temp, deleted on the way out.
+        tmp = tempfile.NamedTemporaryFile(suffix=".tdf", delete=False)
+        tmp.write(blob)
+        tmp.close()
+        path = Path(tmp.name)
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            return _read_conn(conn, source)
+        finally:
+            conn.close()
+    finally:
+        if tmp is not None:
+            path.unlink(missing_ok=True)
+
+
+def _read_conn(conn: sqlite3.Connection, source: str) -> TdfAcquisition:
+    out = TdfAcquisition(source=source)
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'")}
+
+    if "DiaFrameMsMsWindows" in tables:
+        rows = conn.execute(
+            "SELECT WindowGroup, ScanNumBegin, ScanNumEnd, IsolationMz, "
+            "IsolationWidth, CollisionEnergy FROM DiaFrameMsMsWindows "
+            "ORDER BY WindowGroup, ScanNumBegin"
+        ).fetchall()
+        out.windows = [
+            DiaWindow(int(g), int(sb), int(se), float(mz), float(w), float(ce))
+            for g, sb, se, mz, w, ce in rows
+        ]
+
+    # GlobalMetadata is the tdf's own key/value table (instrument, acquisition
+    # software, sample name). Absent in some older schemas — not an error.
+    if "GlobalMetadata" in tables:
+        for k, v in conn.execute("SELECT Key, Value FROM GlobalMetadata"):
+            out.properties[str(k)] = str(v)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# What to actually write in the SDRF
+# ---------------------------------------------------------------------------
+
+def describe_isolation_window(acq: TdfAcquisition) -> dict:
+    """Decide what `comment[isolation window width]` can honestly carry.
+
+    The column is a single scalar (`pattern: ^\\d+(\\.\\d+)?$`, examples 25/8/4),
+    which assumes uniform SWATH-style windows. diaPASEF windows are variable by
+    design, and no single number is correct for them — so the honest value is
+    the reserved word, with the measured table going in the report. Deriving a
+    mean or a span/count average produces a plausible wrong number that passes
+    both the regex and parse_sdrf.
+    """
+    if not acq.windows:
+        return {
+            "acquisition": "not DIA (no DiaFrameMsMsWindows rows)",
+            "sdrf_value": None,
+            "rationale": "no DIA window table in this run",
+        }
+    uniform = acq.uniform_width
+    lo, hi = acq.mz_range
+    ce_lo, ce_hi = acq.ce_range
+    common = {
+        "n_windows": len(acq.windows),
+        "n_window_groups": len({w.window_group for w in acq.windows}),
+        "widths": acq.widths,
+        "mz_range": [round(lo, 2), round(hi, 2)],
+        "ce_range": [ce_lo, ce_hi],
+    }
+    if uniform is not None:
+        return {
+            **common,
+            "acquisition": "DIA, uniform windows",
+            "sdrf_value": f"{uniform:g}",
+            "rationale": "every window has the same width, so the scalar column can carry it",
+        }
+    return {
+        **common,
+        "acquisition": "DIA, variable windows (diaPASEF)",
+        "sdrf_value": "not available",
+        "rationale": (
+            f"{len(acq.widths)} distinct widths ({min(acq.widths):g}-{max(acq.widths):g} m/z); "
+            "comment[isolation window width] is a single scalar and cannot express them. "
+            "Do NOT compute a mean or (span/n_windows) — that yields a number matching no "
+            "actual window, and it passes both the regex and parse_sdrf. Put the measured "
+            "table in the report instead."
+        ),
+    }
+
+
+def render(acq: TdfAcquisition) -> str:
+    """Human-readable summary for the CLI and for pasting into a report."""
+    d = describe_isolation_window(acq)
+    lines = [f"source: {acq.source or '(local)'}", f"acquisition: {d['acquisition']}"]
+    if instrument := acq.properties.get("InstrumentName"):
+        lines.append(f"instrument: {instrument}")
+    if not acq.windows:
+        return "\n".join(lines)
+
+    lines += [
+        f"windows: {d['n_windows']} in {d['n_window_groups']} group(s)",
+        f"m/z coverage: {d['mz_range'][0]:.2f} - {d['mz_range'][1]:.2f}",
+        f"collision energy: {d['ce_range'][0]:g} - {d['ce_range'][1]:g} eV",
+        f"widths ({len(d['widths'])} distinct): "
+        + ", ".join(f"{w:g}" for w in d["widths"]),
+        "",
+        f"{'grp':>4} {'scanBeg':>8} {'scanEnd':>8} {'IsolationMz':>12} "
+        f"{'IsolWidth':>10} {'CE':>7}",
+    ]
+    for w in acq.windows:
+        lines.append(
+            f"{w.window_group:>4} {w.scan_begin:>8} {w.scan_end:>8} "
+            f"{w.isolation_mz:>12.2f} {w.isolation_width:>10.2f} "
+            f"{w.collision_energy:>7.1f}"
+        )
+    lines += ["", f"comment[isolation window width] -> {d['sdrf_value']}",
+              f"  {d['rationale']}"]
+    return "\n".join(lines)
+
+
+def analyze(source: str) -> TdfAcquisition:
+    """Fetch (or open) an `analysis.tdf` and read its acquisition tables."""
+    return read_tdf(fetch_tdf(source), source=source)

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -10,6 +10,7 @@ Usage:
   python -m tools massive-files <PXD|MSV|task>     # MassIVE raw/acquisition file resolver
   python -m tools review-gate <command>             # independent-review receipt gate
   python -m tools audit-existing <file.sdrf.tsv>    # audit an already-annotated dataset
+  python -m tools bruker-dia <url|path>             # DIA windows from Bruker analysis.tdf
 """
 
 from __future__ import annotations
@@ -189,6 +190,29 @@ def cmd_audit_existing(args: argparse.Namespace) -> int:
     return 1 if report.blockers else 0
 
 
+def cmd_bruker_dia(args: argparse.Namespace) -> int:
+    """Read DIA isolation windows out of a Bruker .d archive without downloading it."""
+    import json
+
+    from tools.bruker_tdf import ZipRangeError, analyze, describe_isolation_window, render
+
+    try:
+        acq = analyze(args.source)
+    except ZipRangeError as exc:
+        print(f"error: {exc}")
+        return 2
+    if args.json:
+        print(json.dumps({
+            "source": acq.source,
+            "instrument": acq.properties.get("InstrumentName"),
+            "windows": [vars(w) for w in acq.windows],
+            "isolation_window": describe_isolation_window(acq),
+        }, indent=2))
+    else:
+        print(render(acq))
+    return 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="python -m tools",
@@ -273,6 +297,17 @@ def main() -> None:
     p.add_argument("--organism", action="append", default=None,
                    help="organism registered in PRIDE (repeatable); omitted = organism check skipped")
 
+    # bruker-dia
+    p = subparsers.add_parser(
+        "bruker-dia",
+        help="Read DIA isolation windows from a Bruker analysis.tdf (HTTP-range, no download)",
+    )
+    p.add_argument(
+        "source",
+        help="URL or path of a .d.zip archive, or a path to an extracted analysis.tdf",
+    )
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+
     args = parser.parse_args()
 
     # Set default db path for cellline commands
@@ -290,6 +325,7 @@ def main() -> None:
         "verify": cmd_verify,
         "review-gate": cmd_review_gate,
         "audit-existing": cmd_audit_existing,
+        "bruker-dia": cmd_bruker_dia,
     }
 
     sys.exit(commands[args.command](args))


### PR DESCRIPTION
Closes #33 — the `sdrf-skills` half (the spec half belongs to `bigbio/sdrf-templates`; see the end).

## What this does

`analysis.tdf` inside a Bruker `.d` archive is a plain SQLite database, and PRIDE's HTTPS mirror sends `Accept-Ranges: bytes`. So the ZIP central directory can be read from the tail and that one member range-fetched, instead of downloading a multi-GB archive that no MCP download cap would allow anyway.

**`tools/bruker_tdf.py`** (new, stdlib only — `zlib` + `sqlite3` + `urllib`):

- Range-reads the central directory, **including ZIP64** — not optional here, since a `.d.zip` over 4 GB leaves `0xFFFFFFFF` in the classic record and a parser that ignores it seeks to garbage.
- Computes the member's data offset from the **local** header, whose extra field routinely differs in length from the central directory's; using the central length lands mid-stream and the inflate fails. There is a regression test for exactly this.
- Refuses a server that ignores `Range` and answers `200`, rather than quietly streaming gigabytes.
- Reads `DiaFrameMsMsWindows` (windows, m/z coverage, CE ramp) and `GlobalMetadata` (instrument name).

**`describe_isolation_window()`** decides what the SDRF can honestly carry:

| Situation | Value |
|---|---|
| Every window the same width (SWATH-style) | that width |
| Widths vary (diaPASEF, the common case on timsTOF) | `not available`, with the measured table in the report |

and it names the wrong derivation in its own rationale, because the tempting one is silent: "15 windows spanning 400–1000" → `600/15 = 40` matches **none** of the 15 actual widths, passes the column's `^\d+(\.\d+)?$` regex, and passes `parse_sdrf`.

**CLI**: `python -m tools bruker-dia <url|path> [--json]`, smoke-tested in CI alongside the other subcommands.

**Skills**: `sdrf-techrefine` gains a Bruker section (the command, what it reads, and the uniform-vs-variable rule) — this is squarely its remit, and it could not do it for Bruker before; `sdrf-annotate` §5.6 gets the same pointer. `CLAUDE.md`'s tools list was two subcommands stale (`audit-existing`, now `bruker-dia`).

## Verified live

Against the real archive — `PXD052416`, `HeLa_ATG_KNO_Col1-3_10min_my_stage_0_L7_BL7_1_1907.d.zip`, **3470 MB**:

```
acquisition: DIA, variable windows (diaPASEF)
instrument: timsTOF Ultra
windows: 15 in 5 group(s)
m/z coverage: 400.00 - 1000.00
collision energy: 25.8046 - 48.9467 eV
widths (15 distinct): 29.52, 29.55, 29.99, 31.49, 31.67, 33.51, 34.58, 35.07,
                      37.01, 39.89, 44.53, 45.1, 52.52, 65.06, 74.51

comment[isolation window width] -> not available
```

Those are **exactly** the 15 widths the issue reports. Bytes read: 128 KB tail + 14.7 MB member = **14.8 MB, 234× less than the archive**.

## Tests

16 new in `tests/test_bruker_tdf.py`, all offline and none mocked at the parsing layer: a real ZIP holding a real SQLite `analysis.tdf` is built in a tmpdir and read through the same `Fetcher` interface the HTTP path uses, so the central-directory parse, the offset arithmetic, the inflate and the SQLite read all run for real — only the socket is absent. Covered: member extraction, stored vs deflated, a hand-rolled archive whose **local** extra field diverges from the central one (confirmed to fail if the offset logic regresses), a missing member, a non-ZIP, the variable-width verdict, the uniform-width verdict, a non-DIA run, and the rendered report.

Only the seven window rows the issue quotes verbatim are used as real data; the fixture that exercises the 15-distinct-widths case carries the issue's real width list with placeholder m/z, and says so.

Full suite: **259 passed** (243 before). `ruff check` clean on the new and touched files (the 14 pre-existing errors elsewhere are untouched and predate this).

## Out of scope

The spec half — `comment[isolation window width]` being a single scalar that cannot express variable diaPASEF windows — is a `bigbio/sdrf-templates` change and is not attempted here. Until it lands, both the tool and the skill treat `not available` + the measured table as the honest answer, and the skill says why so it doesn't read as an annotator failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJf59eUdT93HnWi7YxQcDw)_