### PR TITLE
Write characteristics values as bare ontology labels (comment keeps NT=;AC=)

### DIFF
--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -114,6 +114,11 @@ The audit is mechanical and checks only what the deposit can settle:
 | `no_factor_value` | major | no factor value column declared |
 | `characteristics_not_bare_label`, `source_name_convention` | minor | convention drift |
 
+> **Value encoding.** `characteristics[...]` values are written as the **bare ontology label**
+> (e.g. `Homo sapiens`, not `NT=Homo sapiens;AC=NCBITaxon:9606`); only `comment[...]` values keep
+> the `NT=;AC=` form. Structured characteristics (`spiked compound`, `pooled sample`) keep their
+> key-value form. See `sdrf-knowledge` → *Value Encoding: characteristics vs comment*.
+
 Also validate the existing file — it can be structurally valid and still be wrong
 about the deposit, so the two checks are complementary. Validate the way the rest
 of this repo requires: **once per declared template, against the rows that declare

--- a/skills/sdrf-fix/SKILL.md
+++ b/skills/sdrf-fix/SKILL.md
@@ -113,6 +113,19 @@ Verify that `parse_sdrf` is available (run `parse_sdrf --version` or `which pars
 mcp OLS → searchClasses(query="<instrument>", ontologyId="ms")
 ```
 
+### 11. Characteristics as bare ontology label
+Sample metadata uses the plain label; only `comment[...]` keeps `NT=;AC=`.
+
+| Column | Wrong | Correct |
+|--------|-------|---------|
+| `characteristics[organism]` | `NT=Homo sapiens;AC=NCBITaxon:9606` | `Homo sapiens` |
+| `characteristics[disease]` | `NT=lung adenocarcinoma;AC=MONDO:0005097` | `lung adenocarcinoma` |
+| `comment[cleavage agent details]` | — | `NT=Trypsin;AC=MS:1001251` *(unchanged — comment keeps NT/AC)* |
+
+**Fix**: For a `characteristics[...]` value that is a pure `NT=<label>;AC=<accession>` pair,
+replace it with `<label>`. Leave structured characteristics (`spiked compound` `CT=`/`QY=`,
+`pooled sample` `SN=`) and every `comment[...]` value untouched.
+
 ## Fix Procedure
 
 1. **Parse** the SDRF into a structured table

--- a/skills/sdrf-knowledge/SKILL.md
+++ b/skills/sdrf-knowledge/SKILL.md
@@ -73,6 +73,25 @@ Example: disease → "MONDO, EFO, DOID, PATO" → search these ontologies via OL
 | **comment** | `comment[x]` | Technical/run properties ("how was it measured?") |
 | **factor value** | `factor value[x]` | Experimental variable ("what are we comparing?") |
 
+## Value Encoding: characteristics vs comment
+
+Sample metadata and technical metadata are encoded differently:
+
+- **`characteristics[...]` → bare ontology label (free text).** Write the value as the
+  OLS term's label only — **not** `NT=;AC=`. For example use `Homo sapiens`, not
+  `NT=Homo sapiens;AC=NCBITaxon:9606`; `liver`, not `NT=liver;AC=UBERON:0002107`;
+  `lung adenocarcinoma`, not `NT=lung adenocarcinoma;AC=MONDO:0005097`. The validator
+  resolves the label to its accession, so the bare label is complete.
+- **`comment[...]` → keep the `NT=<OLS label>;AC=<accession>` key-value form** (instrument,
+  cleavage agent details, modification parameters, proteomics data acquisition method, etc.).
+
+Exceptions (kept structured, not converted to a bare label):
+- Structured `characteristics` that carry qualifier keys — `characteristics[spiked compound]`
+  (`CT=`/`QY=`/`PS=`), `characteristics[pooled sample]` (`SN=`) — keep their key-value form.
+- `characteristics[age]` and similar pattern values (`50Y`) are not ontology terms.
+- `factor value[...]` mirrors the column it derives from: bare label if it mirrors a
+  `characteristics` column, `NT=;AC=` if it mirrors a `comment` column.
+
 ## Reserved Words
 
 These values have special meaning in SDRF:

--- a/tests/test_fixer.py
+++ b/tests/test_fixer.py
@@ -109,3 +109,31 @@ class TestIndividualFixers:
         content = "source name\tcharacteristics[disease]\n" "s1\t cancer \n"
         _fixed, report = fix_sdrf(content)
         assert any(f.pattern == "whitespace" for f in report.fixes)
+
+    def test_characteristics_ntac_to_bare_label(self):
+        content = (
+            "source name\tcharacteristics[organism]\n"
+            "s1\tNT=Homo sapiens;AC=NCBITaxon:9606\n"
+        )
+        fixed, report = fix_sdrf(content)
+        assert "\tHomo sapiens\n" in fixed
+        assert "NT=" not in fixed.splitlines()[1]
+        assert any(f.pattern == "characteristics_bare_label" for f in report.fixes)
+
+    def test_comment_keeps_ntac(self):
+        content = (
+            "source name\tcomment[cleavage agent details]\n"
+            "s1\tNT=Trypsin;AC=MS:1001251\n"
+        )
+        fixed, report = fix_sdrf(content)
+        assert "NT=Trypsin;AC=MS:1001251" in fixed
+        assert not any(f.pattern == "characteristics_bare_label" for f in report.fixes)
+
+    def test_structured_characteristic_untouched(self):
+        content = (
+            "source name\tcharacteristics[spiked compound]\n"
+            "s1\tCT=spike;QY=10;PS=PEPTIDE\n"
+        )
+        fixed, report = fix_sdrf(content)
+        assert "CT=spike;QY=10;PS=PEPTIDE" in fixed
+        assert not any(f.pattern == "characteristics_bare_label" for f in report.fixes)

--- a/tools/sdrf_fixer.py
+++ b/tools/sdrf_fixer.py
@@ -204,6 +204,27 @@ def _fix_dda_dia(value: str) -> tuple[str | None, str]:
     return None, ""
 
 
+def _fix_characteristics_bare_label(value: str) -> tuple[str | None, str]:
+    """Sample-metadata (characteristics) ontology values are written as the bare OLS label.
+
+    Convert a pure ``NT=<label>;AC=<accession>`` pair to just ``<label>`` (e.g.
+    ``NT=Homo sapiens;AC=NCBITaxon:9606`` -> ``Homo sapiens``). Only applied to
+    ``characteristics[...]`` columns; ``comment[...]`` values keep the NT=;AC= form.
+    Structured characteristics that carry qualifier keys (spiked compound CT=/QY=,
+    pooled sample SN=, etc.) are left untouched, since they are not a plain NT/AC pair.
+    """
+    parts = [p for p in value.split(";") if p.strip()]
+    kv: dict[str, str] = {}
+    for p in parts:
+        if "=" not in p:
+            return None, ""  # already a bare label (or free text) -> leave it
+        k, v = p.split("=", 1)
+        kv[k.strip().upper()] = v.strip()
+    if set(kv) != {"NT", "AC"} or not kv.get("NT"):
+        return None, ""  # structured value (extra keys) -> keep as-is
+    return kv["NT"], "characteristics value written as the bare ontology label (dropped NT=;AC=)"
+
+
 def _fix_whitespace(value: str) -> tuple[str | None, str]:
     """Fix trailing/leading whitespace."""
     stripped = value.strip()
@@ -247,6 +268,12 @@ def fix_sdrf(source: str | Path) -> tuple[str, FixReport]:
 
             # Apply fixes in priority order
             fixers = []
+
+            # Pattern 0: characteristics ontology values -> bare OLS label.
+            # Sample metadata uses the plain label; comment columns keep NT=;AC=.
+            # Runs first so later fixes (e.g. case) act on the resulting label.
+            if col.raw_name.strip().lower().startswith("characteristics["):
+                fixers.append(("characteristics_bare_label", _fix_characteristics_bare_label))
 
             # Pattern 1: UNIMOD swaps (modification parameters)
             if inner == "modification parameters":


### PR DESCRIPTION
## Convention
Sample-metadata (`characteristics[...]`) ontology values are written as the **bare OLS label**, not the `NT=;AC=` key-value form:

| | Before | After |
|---|---|---|
| `characteristics[organism]` | `NT=Homo sapiens;AC=NCBITaxon:9606` | `Homo sapiens` |
| `characteristics[disease]` | `NT=lung adenocarcinoma;AC=MONDO:0005097` | `lung adenocarcinoma` |
| `comment[cleavage agent details]` | `NT=Trypsin;AC=MS:1001251` | *unchanged — comment keeps NT/AC* |

This matches the existing `characteristics_not_bare_label` convention and the way the validator resolves a bare label to its accession.

## Changes
- **`tools/sdrf_fixer.py`** — new characteristics-only fix that converts a pure `NT=<label>;AC=<accession>` pair to `<label>`. Guarded to (a) `characteristics[...]` columns and (b) values whose only keys are `NT` and `AC`, so every `comment[...]` value and every structured characteristic (`spiked compound` `CT=`/`QY=`, `pooled sample` `SN=`, `age` `50Y`) is left untouched. Runs before case normalization.
- **`skills/sdrf-knowledge`** — new *Value Encoding: characteristics vs comment* section (incl. exceptions and factor-value mirroring).
- **`skills/sdrf-fix`** — new pattern 11; **`skills/sdrf-annotate`** — value-encoding note next to the `characteristics_not_bare_label` flag.
- **tests** — 3 new cases (bare-label conversion, comment untouched, structured untouched). Full suite 19 passing.

Note: this changes only guidance + the deterministic fixer; it does not re-annotate existing datasets. Run `sdrf_fixer` over the corpus (or a targeted set) as a follow-up if you want the existing `NT=;AC=` characteristics converted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic normalization of ontology-formatted values in `characteristics[...]` fields to bare labels.
  * Preserved structured characteristic values and existing `comment[...]` formats.

* **Documentation**
  * Clarified SDRF value-encoding rules, including exceptions for structured, pattern, and factor values.

* **Tests**
  * Added coverage for characteristic normalization and preservation of unaffected values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->