### PR TITLE
Skills rules audit: fix stale rules and add missing ones

### DIFF
--- a/skills/sdrf-cellline/SKILL.md
+++ b/skills/sdrf-cellline/SKILL.md
@@ -220,7 +220,7 @@ Cellosaurus `SX` field (`Sex: Female | Male | Mixed sex | Sex unspecified`):
 
 - `Female` → `female`
 - `Male` → `male`
-- `Mixed sex` → `mixed`
+- `Mixed sex` → `not applicable` (or `pooled` for a deliberate pool — `characteristics[sex]` has no `mixed` value)
 - `Sex unspecified` / absent → `not available`
 
 Lowercase always. Never `M`/`F`. The `cell-lines` template inherits

--- a/skills/sdrf-contribute/SKILL.md
+++ b/skills/sdrf-contribute/SKILL.md
@@ -84,11 +84,15 @@ audit instead of repeating it, and confirm the user chose `fix` or `reannotate`.
 
 Before contributing, the SDRF must pass validation:
 
-1. **Suggest programmatic validation**:
+1. **Suggest programmatic validation** — run once per declared `comment[sdrf template]`, each against the rows that declare it; every run must pass:
    ```bash
    pip install sdrf-pipelines
-   parse_sdrf validate-sdrf --sdrf_file {PXD}.sdrf.tsv
+   parse_sdrf validate-sdrf --sdrf_file datasets/{PXD}/{PXD}.sdrf.tsv --template ms-proteomics
+   # repeat --template <organism/experiment template> for each declared template
    ```
+   The target repo's CI **SDRF review gate** also checks coordinate collisions and ragged rows on every changed file — reproduce those locally before pushing.
+
+   **Zero-deletion guard (mandatory before PR):** stage only your new folder (`git add datasets/{PXD}/`, never `git add -A`), then run `git diff --cached --name-status` and confirm every line is `A` — abort if any `D`/`M`/`R` touches a dataset you did not create.
 
 2. **Run `/sdrf:validate`** for a thorough check including ontology verification
 
@@ -129,10 +133,12 @@ datasets/
 ```
 
 ### 3.2 Save the file
-Save the SDRF content to the correct path:
+Save the SDRF content to the correct path (note the top-level `datasets/`):
 ```text
-{PXD}/{PXD}.sdrf.tsv
+datasets/{PXD}/{PXD}.sdrf.tsv
 ```
+If the SDRF still has unverifiable sample->file/channel maps or demographics, put it under
+`sandbox/{PXD}/` instead (CI-exempt) with a `BLOCKED:` note — never PR unresolved data to `datasets/`.
 
 Ensure the file:
 - Uses tab delimiters (not spaces or commas)
@@ -184,11 +190,11 @@ gh pr create \
 **Factor values**: {factor_description}
 
 ### Validation
-- [x] Validated with `sdrf-pipelines validate-sdrf`
-- [x] Ontology terms verified via OLS
+- [ ] Validated with `parse_sdrf validate-sdrf` (per declared template)
+- [ ] Ontology terms verified via OLS
+- [ ] Coordinate rows unique; no ragged rows
 
-### Annotation source
-Annotated using [sdrf-skills](https://github.com/bigbio/sdrf-skills).
+_Tick each box only after it actually passes._
 EOF
 )"
 ```

--- a/skills/sdrf-knowledge/SKILL.md
+++ b/skills/sdrf-knowledge/SKILL.md
@@ -60,9 +60,16 @@ Example: disease → "MONDO, EFO, DOID, PATO" → search these ontologies via OL
 - Each **column** = a property of the sample or run
 - Column names are **case-sensitive** and follow the patterns above
 - First column is always `source name` (unique biological sample identifier)
-- The combination of (`source name`, `assay name`) must be unique per row
+- Row identity: (`source name`, `assay name`, `comment[label]`) MUST be unique (error); (`source name`, `assay name`) SHOULD be unique (warning). In multiplexed (TMT/iTRAQ) data the same `assay name` deliberately repeats across label channels, so `source name`+`assay name` alone is NOT unique.
+- De-duplication coordinate: (`source name`, `characteristics[biological replicate]`, `comment[technical replicate]`, `comment[fraction identifier]`) must be unique across rows — never use `technical replicate` or `fraction identifier` as a row counter
 - No trailing whitespace in any cell or column name
 - No empty cells in required columns
+- **Data files are vendor RAW** (`.raw`/`.d`/`.wiff`/`.wiff2`) in `comment[data file]` — never peak lists (`.mgf`/`.mzML`/`.mzXML`); a peak-list reference validates structurally but breaks reprocessing
+- **At least one `factor value[...]`** column must be present (the experimental variable)
+- **Acquisition method**: `comment[proteomics data acquisition method]` is REQUIRED for MS files and must be a descendant of `PRIDE:0000659` (DDA `PRIDE:0000627`, DIA `PRIDE:0000450`, PRM `PRIDE:0000629`, SRM `PRIDE:0000630`); never `NCIT:C161786`/`MS:1000206`, and there is no `comment[dia method]` column
+- **Carrier / reference channels** (single-cell / TMT): `comment[carrier channel]` = `PRIDE:0000901`, `comment[reference channel]` = `PRIDE:0000899` (not `PRIDE:0000941`/`0000942`); values are TMT channel labels (e.g. `TMT131C`)
+- **Never write SDRF with pandas `to_csv`** — it renames legitimately repeated headers (`comment[modification parameters].1`); write raw TSV preserving duplicated column names
+- **Multiple values = repeat the whole column** with the same header (there is no delimiter-separated list)
 
 ## Column Type System
 

--- a/skills/sdrf-terms/SKILL.md
+++ b/skills/sdrf-terms/SKILL.md
@@ -77,9 +77,9 @@ Example: User has DOID term, needs EFO equivalent
   3. Present both options with accessions
 ```
 
-For disease terms, SDRF accepts EFO, MONDO, or DOID. Recommend:
-- **EFO** as first choice (most commonly used in SDRF)
-- **MONDO** as second choice (good cross-references)
+For disease terms, SDRF accepts MONDO, EFO, or DOID. Recommend (matches TERMS.tsv and sdrf-annotate):
+- **MONDO** as first choice (primary; strong cross-references)
+- **EFO** as second choice
 - **DOID** as third choice
 
 ## Step 5: Present Results

--- a/skills/sdrf-validate/SKILL.md
+++ b/skills/sdrf-validate/SKILL.md
@@ -96,6 +96,8 @@ Additionally, read the individual template YAML at `spec/sdrf-proteomics/sdrf-te
 - [ ] `comment[data file]`
 - [ ] `comment[fraction identifier]`
 - [ ] `comment[technical replicate]`
+- [ ] `comment[instrument]`
+- [ ] `comment[proteomics data acquisition method]` (descendant of `PRIDE:0000659`)
 - [ ] `comment[sdrf version]`
 
 For all other template-specific columns, read from TERMS.tsv rather than using a hardcoded list.
@@ -252,7 +254,10 @@ When validating multiple files, prefer small bounded batches. Do not launch larg
 ## Step 5: Consistency Checks
 
 - [ ] All rows have the same number of columns (no ragged rows)
-- [ ] `source name` + `assay name` combination is unique per row
+- [ ] Uniqueness: (`source name` + `assay name` + `comment[label]`) is unique (ERROR); (`source name` + `assay name`) unique (WARN); coordinate (`source name`, `characteristics[biological replicate]`, `comment[technical replicate]`, `comment[fraction identifier]`) unique across rows — no duplicate coordinates
+- [ ] Value encoding by column type: `characteristics[...]` ontology values are the BARE label (flag a pure `NT=;AC=` pair); `comment[...]` CV values are `NT=<label>;AC=<accession>`; structured characteristics (`spiked compound` CT=/QY=, `pooled sample` SN=) keep key-value
+- [ ] `comment[proteomics data acquisition method]` resolves to a descendant of `PRIDE:0000659`; reject `MS:1000206`/`MS:1003221`/`NCIT:C161786` and any `comment[dia method]` column
+- [ ] NT/AC agreement: for each `NT=…;AC=…`, the accession's OLS label matches NT= (catches label/accession swaps beyond UNIMOD)
 - [ ] `source name` values follow a consistent naming pattern
 - [ ] `characteristics[biological replicate]` values are sequential integers
 - [ ] `comment[fraction identifier]` values are consistent across samples

--- a/tools/completeness.py
+++ b/tools/completeness.py
@@ -86,7 +86,7 @@ GENERIC_TERMS: dict[str, list[str]] = {
 AGE_PATTERN = re.compile(r"^(\d+[YMWD])+$")
 
 # Valid sex values
-VALID_SEX = {"male", "female", "not available", "not applicable", "mixed"}
+VALID_SEX = {"male", "female", "intersex", "hermaphrodite", "anonymized", "not available", "not applicable", "pooled"}
 
 
 # ---------------------------------------------------------------------------

--- a/tools/sdrf_fixer.py
+++ b/tools/sdrf_fixer.py
@@ -290,7 +290,7 @@ def fix_sdrf(source: str | Path) -> tuple[str, FixReport]:
             fixers.append(("reserved_word", _fix_reserved_words))
 
             # Pattern 6: DDA/DIA terminology
-            if inner in ("dissociation method",) or "acquisition" in inner:
+            if inner == "proteomics data acquisition method":
                 fixers.append(("dda_dia", _fix_dda_dia))
 
             # Pattern 7: Age format


### PR DESCRIPTION
A full audit of all 20 skills + the `tools/` rules against the current spec (`master`) and the established encoding/acquisition/uniqueness policies. Verified accessions against TERMS.tsv and OLS.

## Bugs fixed
| Where | Was | Now |
|---|---|---|
| `sdrf-knowledge` | row identity = (source name, assay name) | (source name, assay name, **comment[label]**) MUST-unique — the old key is wrong for TMT/iTRAQ where `assay name` repeats across channels; added the de-dup coordinate |
| `sdrf-contribute` | save path `{PXD}/…`; validate with no `--template`; PR body pre-ticked `[x]` boxes + "Annotated using sdrf-skills" | `datasets/{PXD}/…`; validate **per declared template**; zero-deletion guard + sandbox-first + CI-gate note; boxes unticked; attribution removed |
| `sdrf-cellline` | Cellosaurus `Mixed sex → mixed` | `not applicable`/`pooled` (`characteristics[sex]` has no `mixed`) |
| `sdrf-terms` | disease precedence EFO-first | MONDO-first (matches TERMS.tsv + sdrf-annotate) |
| `tools/sdrf_fixer.py` | DDA/DIA fix wired to the **dissociation-method** column | restricted to `comment[proteomics data acquisition method]` |
| `tools/completeness.py` | `VALID_SEX` had non-spec `mixed` | spec enum (male/female/intersex/hermaphrodite/anonymized/reserved words) |

## Rules added (were missing across skills)
- **sdrf-knowledge** core rules: vendor RAW (not peak lists) in `comment[data file]`; ≥1 `factor value`; acquisition method a `PRIDE:0000659` descendant (no `comment[dia method]`); carrier/reference channels = `PRIDE:0000901`/`0000899`; never pandas `to_csv`; multi-value = repeat the whole column.
- **sdrf-validate**: acquisition method added to always-required; Step 5 now checks the correct uniqueness keys + de-dup coordinate, value-encoding by column type, acquisition-method ancestry (rejecting `MS:1000206`/`NCIT:C161786`), and NT/AC label agreement.

Tests: `test_fixer` + `test_completeness` — 43 passing.

_Note: the spec `dev` branch is stale (still documents `comment[dia method]`); these rules track `master`, which is authoritative._