### PR TITLE
Skills rules round 2: concepts, design counting, targeted routing, invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,22 @@ reimplementing merge semantics.
    approval cannot outlive the content it describes. `gate` exits 1 while review is pending.
    Enforcement lives in the CLI, not the Stop hook, because four of the five platforms this repo
    supports cannot run Claude Code hooks at all.
+9. **Vendor RAW only in `comment[data file]`** — `.raw`/`.d`/`.wiff`/`.wiff2`, never peak lists
+   (`.mgf`/`.mzML`/`.mzXML`). A peak-list reference validates structurally but breaks reprocessing.
+10. **Row-uniqueness coordinate**: (`source name`, `characteristics[biological replicate]`,
+    `comment[technical replicate]`, `comment[fraction identifier]`) must be unique; the spec MUST-unique
+    key is `source name`+`assay name`+`comment[label]`. The `sdrf-annotated-datasets` review gate rejects
+    collisions, so annotate/fix/contribute must produce it.
+11. **Value encoding by column type**: `characteristics[...]` = the bare ontology label (never
+    `NT=;AC=`); `comment[...]` = `NT=<OLS label>;AC=<accession>`; structured characteristics
+    (`spiked compound` `CT=/QY=`, `pooled sample` `SN=`) keep key-value.
+12. **Acquisition method** (`comment[proteomics data acquisition method]`, required for MS) is a
+    descendant of `PRIDE:0000659` — DDA `PRIDE:0000627`, DIA `PRIDE:0000450`, PRM `PRIDE:0000629`,
+    SRM `PRIDE:0000630`; never `MS:1000206`/`NCIT:C161786`; `comment[dia method]` was removed.
+13. **Contribution hygiene**: a `datasets/` PR adds exactly one new `{ACC}/` folder —
+    `git diff --cached --name-status` must show 0 deletions/modifications to other datasets;
+    unresolved datasets go to CI-exempt `sandbox/` with a `BLOCKED:` note; no AI/assistant attribution
+    in public commits or PRs. Never invent sample->file/channel maps, demographics, or runs.
 
 ## Landmines
 

--- a/skills/sdrf-convert/SKILL.md
+++ b/skills/sdrf-convert/SKILL.md
@@ -25,7 +25,10 @@ sdrf-pipelines can convert SDRF to these formats:
 ## Pipeline Recommendation Logic
 
 ```text
-Is it DIA data?
+Is it targeted (PRM/SRM)?   acquisition method = PRIDE:0000629 (PRM) / PRIDE:0000630 (SRM)
+├── YES → Skyline / OpenSWATH (targeted) — not the DDA/DIA tree below
+│
+Is it DIA data?            acquisition method = PRIDE:0000450 (incl. diaPASEF PRIDE:0000650, SWATH PRIDE:0000447)
 ├── YES → DIA-NN (fastest, best DIA performance)
 │         Also consider: quantms with DIA module
 │

--- a/skills/sdrf-design/SKILL.md
+++ b/skills/sdrf-design/SKILL.md
@@ -22,6 +22,12 @@ Extract from the SDRF:
 - **Instruments**: From comment[instrument]
 - **Files per sample**: Count of rows per source name
 
+> **Exclude non-biological channels before counting replicates or testing balance.** Drop rows that are
+> reference / carrier / bridge / empty / pooled / control — `characteristics[sample type]` in {reference,
+> bridge, carrier, empty, pooled, ...-control}, or rows carrying `comment[carrier channel]` (`PRIDE:0000901`) /
+> `comment[reference channel]` (`PRIDE:0000899`). Counting them inflates n and corrupts the TMT/label
+> cross-tabs. Replication = unique `source name` per condition, not raw row count.
+
 ## Step 2: Design Summary
 
 Present a clear summary:

--- a/skills/sdrf-explain/SKILL.md
+++ b/skills/sdrf-explain/SKILL.md
@@ -120,6 +120,16 @@ Think of it this way:
 - comment = "how was it measured?"
 - factor value = "what are we testing?"
 
+### "How do I write a value — plain label or NT=;AC=?"
+It depends on the column TYPE:
+- **characteristics[...]** → the **bare ontology label**: `Homo sapiens`, `liver`, `breast carcinoma`. Not `NT=;AC=` (the validator resolves the label to its accession).
+- **comment[...]** → **`NT=<label>;AC=<accession>`**: `NT=Trypsin;AC=MS:1001251`.
+- **Structured characteristics** keep key=value: `spiked compound` (`CT=;QY=;PS=;AC=;CN=;CV=`), and modifications in `comment[modification parameters]` (`NT=;AC=;TA=;MT=`).
+- **Acquisition method** (`comment[proteomics data acquisition method]`, required for MS) is a descendant of `PRIDE:0000659` — DDA `PRIDE:0000627`, DIA `PRIDE:0000450`, PRM `PRIDE:0000629`, SRM `PRIDE:0000630`.
+
+### "How do I give a column more than one value?"
+You **repeat the whole column** with the same header — there is no comma-separated list. Three modifications = three `comment[modification parameters]` columns; two organism parts = two `characteristics[organism part]` columns.
+
 ### "Why do I need ontology terms?"
 Ontology terms enable:
 1. **Machine readability** — software can group samples by disease automatically

--- a/skills/sdrf-techrefine/SKILL.md
+++ b/skills/sdrf-techrefine/SKILL.md
@@ -141,7 +141,11 @@ has generic names (e.g., "Q Exactive") while raw files have the specific model
 | DDA vs DIA | Spectrum analysis | `NT=Data-dependent acquisition;AC=PRIDE:0000627` |
 
 **What to check**: Is the acquisition method in the SDRF correct? Misclassification
-of DDA as DIA (or vice versa) affects which analysis pipelines can be used.
+of DDA as DIA (or vice versa) affects which analysis pipelines can be used. Write the value in
+`comment[proteomics data acquisition method]` as a descendant of `PRIDE:0000659` — DDA `PRIDE:0000627`,
+DIA `PRIDE:0000450`; when techsdrf identifies a named DIA variant, prefer its specific accession
+(diaPASEF `NT=diaPASEF;AC=PRIDE:0000650`, SWATH `NT=SWATH MS;AC=PRIDE:0000447`); plain DIA `PRIDE:0000450`
+remains acceptable. There is no `comment[dia method]` column.
 
 ### 5.3 Fragmentation
 | Detected Field | Source | Example |


### PR DESCRIPTION
Follow-up to the rules audit (#63), adding the guidance that audit flagged as missing but out of scope for the bug-fix PR.

- **sdrf-explain** — the two most-asked concepts were absent: *value encoding by column type* (characteristics = bare label, comment = `NT=;AC=`, structured stays key-value) and *multi-value = repeat the whole column*, plus the acquisition-method concept.
- **sdrf-design** — exclude reference/carrier/bridge/pooled/control channels before counting replicates or testing TMT/label balance (they inflate n and corrupt the cross-tabs); replication = unique `source name`, not row count. Carrier=`PRIDE:0000901`, reference=`PRIDE:0000899`.
- **sdrf-convert** — add a **targeted (PRM/SRM)** branch that routes to Skyline/OpenSWATH ahead of the DDA/DIA tree; annotate the DIA branch with the variant accessions.
- **sdrf-techrefine** — name the acquisition column and, on a detected DIA variant, **prefer its specific accession** (diaPASEF `PRIDE:0000650`, SWATH `PRIDE:0000447`); plain DIA `PRIDE:0000450` remains acceptable; no `comment[dia method]`.
- **CLAUDE.md** — added invariants 9-13 to the authoritative doc: vendor RAW (not peak lists), row-uniqueness coordinate, value-encoding by column type, acquisition under `PRIDE:0000659`, and contribution hygiene / no-fabrication.

**diaPASEF/SWATH decision** (you asked): prefer the *specific* descendant accession when the variant is named; plain DIA `PRIDE:0000450` stays valid (all are descendants of 659). Applied consistently in techrefine + convert.

Docs-only; complements #63 (no file overlap).