### PR TITLE
Prevent the writer artifacts found across the annotated corpus

### DIFF
--- a/skills/sdrf-fix/SKILL.md
+++ b/skills/sdrf-fix/SKILL.md
@@ -126,6 +126,23 @@ Sample metadata uses the plain label; only `comment[...]` keeps `NT=;AC=`.
 replace it with `<label>`. Leave structured characteristics (`spiked compound` `CT=`/`QY=`,
 `pooled sample` `SN=`) and every `comment[...]` value untouched.
 
+### 12. Writer artifacts (accession syntax, Python repr, CSV quoting)
+Faults that survive validation because they parse into something wrong rather than failing.
+
+| Wrong | Correct | Why |
+|-------|---------|-----|
+| `AC=1001251` | `AC=MS:1001251` | a bare number is unresolvable |
+| `AC=PRIDE_0000568` | `AC=PRIDE:0000568` | colon separates prefix and id |
+| `TA=['C']` | `TA=C` | Python list left inside a key=value field |
+| `"NT=Trypsin;AC=MS:1001251"` | `NT=Trypsin;AC=MS:1001251` | CSV writer quoted the value |
+| `NT=not applicable;AC=not available` | `not applicable` | reserved words are written bare |
+| `comment[modification parameters].1` | `comment[modification parameters]` | pandas suffix splits a repeated column |
+| `NT=Lys-C;AC=MS:1001309`, `…1310`, `…1311` | all `AC=MS:1001309` | an accession must not increment per row |
+
+**Fix**: `python -m tools fix <file>` handles all of these. The bare-accession prefix is only
+restored when the column maps to exactly one ontology, so an ambiguous column is left alone;
+an incrementing accession needs the correct term confirmed before collapsing the run.
+
 ## Fix Procedure
 
 1. **Parse** the SDRF into a structured table

--- a/skills/sdrf-knowledge/SKILL.md
+++ b/skills/sdrf-knowledge/SKILL.md
@@ -71,6 +71,38 @@ Example: disease → "MONDO, EFO, DOID, PATO" → search these ontologies via OL
 - **Never write SDRF with pandas `to_csv`** — it renames legitimately repeated headers (`comment[modification parameters].1`); write raw TSV preserving duplicated column names
 - **Multiple values = repeat the whole column** with the same header (there is no delimiter-separated list)
 
+## Writing SDRF Safely (writer-side rules)
+
+Every rule here corresponds to a defect class found across the public annotated corpus.
+They are cheap to honour when writing and expensive to find later, because each one
+**parses into the wrong thing instead of failing loudly** — the file still validates.
+
+1. **An accession always carries its ontology prefix.** `AC=MS:1001251`, never `AC=1001251`.
+   A bare number is unresolvable and the intended ontology is only recoverable from context.
+2. **Prefix and id are separated by a colon**, never an underscore: `PRIDE:0000568`, not
+   `PRIDE_0000568`.
+3. **The accession for a term is constant.** If several rows carry the same `NT=`, they carry
+   the same `AC=`. An accession that increments down the rows (`MS:1001309`, `MS:1001310`,
+   `MS:1001311`, … all labelled `Lys-C`) is a generator bug — it names a different, real,
+   wrong term on every row.
+4. **Never emit Python repr into a cell.** No `['C']`, `None`, `nan`, `null`, `"['breast cancer']"`.
+   Watch key=value fields especially: `TA=['C']` must be `TA=C` — a whole-cell artifact check
+   will not catch one nested inside `NT=…;AC=…;TA=…`.
+5. **Do not let a CSV writer quote the value.** `"NT=timsTOF HT;AC=MS:1003404"` is a value whose
+   first character is a quote, not a quoted value, once it is read as TSV.
+6. **Reserved words are written bare**, never wrapped: `not applicable`, not
+   `NT=not applicable;AC=not available`.
+7. **Never write SDRF with pandas `to_csv`.** It renames legitimately repeated columns
+   (`comment[modification parameters].1`), which silently turns one repeated column into several
+   distinct ones, so a reader keyed on the name sees only the first. Write raw TSV lines and
+   preserve duplicate headers exactly.
+8. **Ages carry a unit** from `Y`/`M`/`W`/`D`: `58Y`, not `58` and not `58 years`.
+9. **One value per cell.** Several modifications means several
+   `comment[modification parameters]` columns — never concatenate them into one cell.
+
+`tools/sdrf_fixer.py` repairs 1, 2, 4, 5, 6, 7 and 8 deterministically; run it before
+presenting or contributing any SDRF you generated.
+
 ## Column Type System
 
 | Type | Format | Purpose |

--- a/tests/test_fixer.py
+++ b/tests/test_fixer.py
@@ -137,3 +137,58 @@ class TestIndividualFixers:
         fixed, report = fix_sdrf(content)
         assert "CT=spike;QY=10;PS=PEPTIDE" in fixed
         assert not any(f.pattern == "characteristics_bare_label" for f in report.fixes)
+
+    def test_kv_python_artifact(self):
+        content = (
+            "source name\tcomment[modification parameters]\n"
+            "s1\tNT=Carbamidomethyl;AC=UNIMOD:4;MT=Fixed;TA=['C']\n"
+        )
+        fixed, report = fix_sdrf(content)
+        assert "TA=C" in fixed and "TA=['C']" not in fixed
+        assert any(f.pattern == "kv_python_artifact" for f in report.fixes)
+
+    def test_quoted_cell_unwrapped(self):
+        # A CSV writer may leave the whole value quoted. Reading and rewriting drops the
+        # quotes, so the value must come back out unwrapped either way.
+        content = 'source name\tcomment[instrument]\ns1\t"NT=timsTOF HT;AC=MS:1003404"\n'
+        fixed, _report = fix_sdrf(content)
+        assert 'NT=timsTOF HT;AC=MS:1003404' in fixed
+        assert '"NT=' not in fixed
+
+    def test_accession_separator(self):
+        content = "source name\tcomment[fractionation method]\ns1\tNT=SDS PAGE;AC=PRIDE_0000568\n"
+        fixed, report = fix_sdrf(content)
+        assert "AC=PRIDE:0000568" in fixed
+        assert any(f.pattern == "accession_separator" for f in report.fixes)
+
+    def test_bare_accession_gets_prefix(self):
+        content = "source name\tcomment[cleavage agent details]\ns1\tNT=Trypsin;AC=1001251\n"
+        fixed, report = fix_sdrf(content)
+        assert "AC=MS:1001251" in fixed
+        assert any(f.pattern == "bare_accession" for f in report.fixes)
+
+    def test_bare_accession_left_when_column_ontology_ambiguous(self):
+        # a column with no single expected ontology cannot have its prefix inferred
+        content = "source name\tcomment[some unmapped thing]\ns1\tNT=cancer;AC=1234\n"
+        fixed, report = fix_sdrf(content)
+        assert "AC=1234" in fixed
+        assert not any(f.pattern == "bare_accession" for f in report.fixes)
+
+    def test_sentinel_not_wrapped_in_kv(self):
+        content = (
+            "source name\tcomment[cleavage agent details]\n"
+            "s1\tNT=not applicable;AC=not available\n"
+        )
+        fixed, report = fix_sdrf(content)
+        assert "\tnot applicable" in fixed and "NT=not applicable" not in fixed
+        assert any(f.pattern == "sentinel_kv" for f in report.fixes)
+
+    def test_pandas_header_suffix_removed(self):
+        content = (
+            "source name\tcomment[modification parameters]\tcomment[modification parameters].1\n"
+            "s1\tNT=Oxidation;AC=UNIMOD:35\tNT=Acetyl;AC=UNIMOD:1\n"
+        )
+        fixed, report = fix_sdrf(content)
+        assert ".1" not in fixed.splitlines()[0]
+        assert fixed.splitlines()[0].count("comment[modification parameters]") == 2
+        assert any(f.pattern == "pandas_header_suffix" for f in report.fixes)

--- a/tools/sdrf_fixer.py
+++ b/tools/sdrf_fixer.py
@@ -13,7 +13,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from tools.column_ontology_map import UNIMOD_KNOWN, UNIMOD_SWAPS, WRONG_RESERVED
+from tools.column_ontology_map import (
+    UNIMOD_KNOWN,
+    UNIMOD_SWAPS,
+    WRONG_RESERVED,
+    get_ontologies_for_column,
+)
+
+RESERVED_SENTINELS = {"not available", "not applicable"}
 from tools.sdrf_parser import SDRFFile, parse_sdrf, parse_modification
 
 
@@ -100,6 +107,75 @@ _DDA_DIA_FIXES = {
     "mrm": "NT=Selected reaction monitoring;AC=PRIDE:0000630",
     "selected reaction monitoring": "NT=Selected reaction monitoring;AC=PRIDE:0000630",
 }
+
+
+_KV_LIST_RE = re.compile(r"(\b[A-Za-z]{2,3})=\[([^\]]*)\]")
+_ACC_UNDERSCORE_RE = re.compile(r"(AC=)([A-Za-z]+)_([0-9]+)")
+_BARE_ACC_RE = re.compile(r"(AC=)(\d+)(?=;|$)")
+
+
+def _fix_kv_python_artifact(value: str) -> tuple[str | None, str]:
+    """Strip Python list syntax from inside a key=value cell, e.g. TA=['C'] -> TA=C.
+
+    _fix_python_artifacts only matches a cell that is entirely a Python literal, so an
+    artifact embedded in a key=value string (the common case for TA=/PP=) slips past it.
+    """
+    if "=[" not in value:
+        return None, ""
+
+    def repl(m: re.Match) -> str:
+        items = re.findall(r"[^,'\"\s]+", m.group(2))
+        return f"{m.group(1)}={','.join(items)}" if items else m.group(0)
+
+    fixed = _KV_LIST_RE.sub(repl, value)
+    if fixed != value:
+        return fixed, "Stripped Python list syntax from a key=value field"
+    return None, ""
+
+
+def _fix_quoted_cell(value: str) -> tuple[str | None, str]:
+    """Unwrap a cell that a CSV writer quoted, e.g. \"NT=Trypsin;AC=MS:1001251\"."""
+    v = value.strip()
+    if len(v) > 1 and v[0] == v[-1] and v[0] in "\"'" and "=" in v:
+        return v[1:-1], "Removed the quote characters a CSV writer left around the value"
+    return None, ""
+
+
+def _fix_accession_separator(value: str) -> tuple[str | None, str]:
+    """An accession separates prefix and id with a colon: PRIDE_0000568 -> PRIDE:0000568."""
+    fixed = _ACC_UNDERSCORE_RE.sub(r"\1\2:\3", value)
+    if fixed != value:
+        return fixed, "Accession uses ':' between prefix and id, not '_'"
+    return None, ""
+
+
+def _fix_sentinel_kv(value: str) -> tuple[str | None, str]:
+    """A reserved word is written bare, never wrapped: NT=not applicable;AC=not available."""
+    kv = {}
+    for part in value.split(";"):
+        if "=" not in part:
+            return None, ""
+        k, v = part.split("=", 1)
+        kv[k.strip().upper()] = v.strip()
+    if set(kv) == {"NT", "AC"} and kv["NT"].lower() in RESERVED_SENTINELS \
+       and kv["AC"].lower() in RESERVED_SENTINELS:
+        return kv["NT"].lower(), "Reserved word must be written bare, not wrapped in NT=/AC="
+    return None, ""
+
+
+def _fix_bare_accession(value: str, inner_name: str) -> tuple[str | None, str]:
+    """Restore the ontology prefix on a bare numeric accession: AC=1001251 -> AC=MS:1001251.
+
+    The prefix comes from the column's expected ontology, so it is only applied when the
+    column maps to exactly one ontology; an ambiguous column is left alone.
+    """
+    onts = get_ontologies_for_column(inner_name)
+    if len(onts) != 1:
+        return None, ""
+    fixed = _BARE_ACC_RE.sub(lambda m: f"{m.group(1)}{onts[0]}:{m.group(2)}", value)
+    if fixed != value:
+        return fixed, f"Restored the {onts[0]} prefix on a bare accession"
+    return None, ""
 
 
 def _fix_unimod_swap(mod_str: str) -> tuple[str | None, str]:
@@ -286,6 +362,15 @@ def fix_sdrf(source: str | Path) -> tuple[str, FixReport]:
             # Pattern 4: Python artifacts (all columns)
             fixers.append(("python_artifact", _fix_python_artifacts))
 
+            # Writer artifacts seen across the public corpus: a CSV writer's quotes, a
+            # Python list left inside a key=value field, an accession joined with '_',
+            # a reserved word wrapped in NT=/AC=, and a bare numeric accession.
+            fixers.append(("quoted_cell", _fix_quoted_cell))
+            fixers.append(("kv_python_artifact", _fix_kv_python_artifact))
+            fixers.append(("accession_separator", _fix_accession_separator))
+            fixers.append(("sentinel_kv", _fix_sentinel_kv))
+            fixers.append(("bare_accession", lambda v, i=inner: _fix_bare_accession(v, i)))
+
             # Pattern 5: Reserved words (all columns)
             fixers.append(("reserved_word", _fix_reserved_words))
 
@@ -319,7 +404,20 @@ def fix_sdrf(source: str | Path) -> tuple[str, FixReport]:
     for col in sdrf.columns:
         col_key = sdrf.key_for_column(col.index)
         stripped = col.raw_name.strip()
-        if stripped != col.raw_name:
+        # pandas renames legitimately repeated columns (comment[modification parameters].1).
+        # The suffix makes each copy a different column, so readers see only the first.
+        de_suffixed = re.sub(r"(\])\.\d+$", r"\1", stripped)
+        if de_suffixed != stripped:
+            report.fixes.append(FixRecord(
+                row="header",
+                column=col.raw_name,
+                old_value=stripped,
+                new_value=de_suffixed,
+                reason="Removed the pandas duplicate-column suffix; repeated columns are legal in SDRF",
+                pattern="pandas_header_suffix",
+            ))
+            stripped = de_suffixed
+        if col.raw_name.strip() != col.raw_name:
             report.fixes.append(FixRecord(
                 row="header",
                 column=col.raw_name,


### PR DESCRIPTION
Reviewing the 6,200 SDRFs in `bigbio/sdrf-annotated-datasets` turned up several thousand cells carrying faults **a writer should never produce**. Fixing them there is treating the symptom — these belong here, as rules and as deterministic repairs.

They all share one property: **they validate cleanly**, because each parses into something wrong rather than failing loudly.

### Rules added — `sdrf-knowledge` → *Writing SDRF Safely*
| Rule | Seen in the corpus |
|---|---|
| An accession always carries its ontology prefix (`AC=MS:1001251`) | 3,709 cells with `AC=1001251` |
| Prefix and id separated by a colon, never `_` | 203 cells with `PRIDE_0000568` |
| **The accession for a term is constant** | `Lys-C` with `MS:1001309`, `…1310`, `…1311` incrementing per row — in two datasets |
| Never emit Python repr, **including inside key=value fields** | 2,395 cells with `TA=['C']` |
| Do not let a CSV writer quote the whole value | 1,980 cells like `"NT=timsTOF HT;AC=MS:1003404"` |
| Reserved words are written bare | 70 cells with `NT=not applicable;AC=not available` |
| Never write with pandas `to_csv` | 4 files with `comment[modification parameters].1` |
| Ages carry a Y/M/W/D unit | 8,800 cells (`58`, `5 week`) |
| One value per cell | 5,428 modification values concatenated into single cells |

The incrementing-accession one is worth calling out: it is not a typo but a **generator bug**, and it names a *different, real, wrong* term on every row — the hardest possible defect to spot by eye.

### Repairs added — `tools/sdrf_fixer.py`
- **`_fix_kv_python_artifact`** — `TA=['C']` → `TA=C`. The existing artifact check only matched a cell that was *entirely* a Python literal, so the common nested case slipped straight through. This is the gap that let 2,395 cells through.
- **`_fix_bare_accession`** — restores the prefix from the column's expected ontology, and **only when that column maps to exactly one**, so an ambiguous column is left alone rather than guessed at.
- `_fix_accession_separator`, `_fix_sentinel_kv`, `_fix_quoted_cell`.
- Header handling strips the pandas duplicate-column suffix — and no longer reports that change twice (it was being logged as both a suffix fix and a whitespace fix).

### Tests
7 new cases, **26 passing**. Two deliberately assert restraint: a bare accession in a column with no single expected ontology is **left untouched**, and a quoted cell round-trips clean.

Note the fixer cannot safely repair the incrementing-accession or one-value-per-cell cases — the first needs the correct term confirmed before collapsing the run, the second changes the column count — so those are documented as rules with the fix left to a curator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SDRF cleanup for malformed ontology accessions, CSV-quoted values, Python list formatting, reserved words, and duplicated column suffixes.
  * Automatically restores ontology prefixes when the column context is unambiguous.
  * Added safeguards to avoid uncertain accession corrections.

* **Documentation**
  * Added guidance for safely writing SDRF files and correcting common formatting artifacts.

* **Tests**
  * Added coverage for the new SDRF fixes and ambiguity safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->