### PR TITLE
Reconcile SDRF values against the deposit record, not its metadata dropdowns

### DIFF
--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -847,6 +847,52 @@ rather than a shrug.
 - `comment[sdrf template]` → one column per template: `NT={template_name};VV=v{version}` (versions from templates.yaml)
 - `comment[sdrf annotation tool]` → `manual curation` (or tool name if applicable)
 
+## Step 8.5: Reconcile every value against the record — REQUIRED
+
+`parse_sdrf` checks that a value is a well-formed term in the right ontology. It cannot
+check whether the value is **true of this deposit**. Those are different questions, and the
+second one is where annotation actually goes wrong: a batch of 390 files once passed
+`parse_sdrf`, a repository review gate and an automated code reviewer while asserting
+`organism part = heart` for epicardial adipose tissue, annotating human HeLa QC injections as
+mouse heart, writing `Trypsin` for a study that digested nothing, and stamping a patient
+diagnosis on wild-type control runs.
+
+Every one of those came from the same habit: **reading the archive's structured fields
+(`instruments`, `diseases`, `organismParts`, `organisms`) as if they were the record.** They
+are dropdowns the submitter picked at deposition time. The contradicting evidence was
+usually in the same JSON — in the title.
+
+Run the reconciler over the finished file before validating it:
+
+```bash
+python -m tools reconcile <file.sdrf.tsv> --record <project.json> --accession <PXD>
+```
+
+It reports a finding whenever the prose, the title or the run names disagree with what was
+written, and exits non-zero on a blocker. Treat each finding as a question to answer from the
+record, not a value to overwrite blindly.
+
+**What to do with a finding.** Usually the right answer is a sentinel. `not available` is a
+result, not a failure: a wrong specific value is worse for reuse than an honest blank,
+because a downstream consumer has no way to tell it is wrong.
+
+**The four checks worth running by hand even without the tool:**
+
+1. **Read the title.** It catches most organism-part errors on its own. If the title says
+   *epicardial adipose tissue*, *aortic arch* or *carotid plaque*, the sample is not heart —
+   whatever the dropdown says.
+2. **Read the run names.** They are the submitter's own per-run statement and outrank any
+   project-level field. `HCT116_*` and `Hela_*` runs are not the tissue you think you are
+   annotating; `_WT_`, `_Ctrl_`, `_SHAM_` and `_Healthy_` runs are not diseased; a `_DDA_`
+   run in a DIA deposit is a spectral-library run.
+3. **Never broadcast a project-level fact onto every row.** An archive registers one disease
+   for a whole project. Most disease studies contain controls, so asserting that diagnosis on
+   every row is false for half the file — and if it is also the `factor value`, the one
+   contrast the deposit exists for becomes a constant.
+4. **Check the file format against the instrument vendor.** A Bruker instrument writes `.d`,
+   a Thermo writes `.raw`, a SCIEX writes `.wiff`. An instrument that cannot have produced
+   the deposited files is a contradiction that needs no judgement at all.
+
 ## Step 9: Validate with sdrf-pipelines
 
 Before presenting the SDRF to the user, **always** run programmatic validation
@@ -931,6 +977,13 @@ This step is a recommendation only — do not force the user to contribute.
 
 - NEVER re-annotate an already-annotated dataset silently — audit it, report, and
   let the user choose (Step 0.5). Overwriting requires an explicit `reannotate`
+- NEVER take the archive's structured metadata as the record — `instruments`, `diseases`,
+  `organismParts` and `organisms` are submitter dropdowns. Reconcile each against the title,
+  the protocol prose and the run names (Step 8.5), and write a sentinel on disagreement
+- NEVER assert a project-level disease on every row — check for a control arm first
+- NEVER match an ontology term on a keyword without checking the matched word's ROLE.
+  "chymotrypsin-like activity" is a proteasome assay, not a digest; "the presence of
+  pancreatic trypsin" is an analyte; `icat` matches inside "quantifi(cat)ion"
 - NEVER fabricate ontology accessions — always search OLS
 - NEVER guess file names — get them from PRIDE file list
 - NEVER invent sample information not found in the paper or PRIDE metadata

--- a/tests/test_record_reconcile.py
+++ b/tests/test_record_reconcile.py
@@ -129,6 +129,22 @@ class TestOrganism:
     def test_agreement_is_clean(self):
         assert check_organism(rec(title="Mouse heart"), "Mus musculus") is None
 
+    def test_organism_outside_the_vocabulary_is_never_flagged(self):
+        """A yeast deposit whose prose mentions humans must not be reported.
+
+        The check can only reason about species it knows; absence of an unknown species
+        from the text carries no information.
+        """
+        r = rec(title="Saccharomyces cerevisiae proteome",
+                projectDescription="Orthologs of the human complex were compared.")
+        assert check_organism(r, "Saccharomyces cerevisiae") is None
+
+    def test_species_named_only_in_a_reagent_is_ignored(self):
+        """'modified porcine trypsin' is a reagent, not the organism under study."""
+        r = rec(title="Proteome analysis",
+                sampleProcessingProtocol="Digested with modified porcine trypsin overnight.")
+        assert check_organism(r, "Mus musculus") is None
+
 
 class TestOrganismPart:
     def test_title_names_adipose_not_heart(self):

--- a/tests/test_record_reconcile.py
+++ b/tests/test_record_reconcile.py
@@ -1,0 +1,313 @@
+"""Tests for tools.record_reconcile.
+
+Every case here is a defect observed in a real annotated batch, where the written value was a
+valid ontology term that passed `parse_sdrf` and a repository review gate while contradicting
+the deposit it described. The accession in each docstring is the deposit the case came from.
+"""
+
+from __future__ import annotations
+
+from tools.record_reconcile import (
+    BLOCKER,
+    MAJOR,
+    acquisition_from_run_name,
+    check_acquisition,
+    check_cleavage_agent,
+    check_disease,
+    check_instrument,
+    check_labelled,
+    check_organism,
+    check_organism_part,
+    proteases_in_record,
+    reconcile,
+    sentences,
+)
+
+
+def rec(**kw) -> dict:
+    base = {"title": "", "projectDescription": "", "sampleProcessingProtocol": "",
+            "dataProcessingProtocol": "", "quantificationMethods": []}
+    base.update(kw)
+    return base
+
+
+class TestSentences:
+    def test_does_not_split_on_decimals(self):
+        assert len(sentences("Peptides were 1.5 ug. Next step.")) == 2
+
+    def test_does_not_split_on_a_temperature(self):
+        """A trailing '37 °C.' keeps the following clause in the same sentence.
+
+        That merges two sentences, which is the safe direction: a merged sentence carrying
+        both a digest cue and a role-exclusion word is rejected, so the check fails closed.
+        """
+        assert len(sentences("Digested at 37 °C. Peptides were desalted.")) == 1
+
+    def test_does_not_split_on_abbreviations(self):
+        assert len(sentences("Enzymes, e.g. trypsin, were used. Then LC-MS.")) == 2
+
+
+class TestProteaseRole:
+    """The matched word must be playing the part of a digest reagent."""
+
+    def test_tryptic_is_trypsin(self):
+        """PXD044170: '\\btrypsin' does not match 'tryptic', so the real enzyme was lost."""
+        r = rec(sampleProcessingProtocol="Tryptic digestion was performed using the SP3 protocol.")
+        assert proteases_in_record(r) == ["Trypsin"]
+
+    def test_chymotrypsin_like_activity_is_not_a_digest(self):
+        """PXD044170: 'chymotrypsin-like activity' is a proteasome assay readout."""
+        r = rec(projectDescription="Investigation of the UPS showed a higher chymotrypsin-like "
+                                   "activity after TAC.",
+                sampleProcessingProtocol="Tryptic digestion was performed for 50 ug protein.")
+        assert proteases_in_record(r) == ["Trypsin"]
+
+    def test_trypsin_as_the_analyte_is_not_a_digest(self):
+        """PXD026332: a plasma peptidomics study that digests nothing."""
+        r = rec(projectDescription=(
+            "We investigated in plasma of heart failure patients the presence of pancreatic "
+            "trypsin, a major enzyme responsible for digestion. The plasma trypsin levels are "
+            "elevated. The peptides exhibit cleavage sites by trypsin."))
+        assert proteases_in_record(r) == []
+
+    def test_sequential_digest_reports_both_enzymes(self):
+        """PXD027772: the second enzyme sits far from the single 'digested with'."""
+        r = rec(sampleProcessingProtocol=(
+            "30 ug of protein was digested with Lys-C (FUJIFILM Wako) for 4 h and subsequently "
+            "with modified porcine trypsin for 16 h at 37 °C."))
+        assert set(proteases_in_record(r)) == {"Trypsin", "Lys-C"}
+
+    def test_search_setting_still_counts(self):
+        """The submitter stating the search enzyme is still stating the digest."""
+        r = rec(dataProcessingProtocol="The enzyme specificity was trypsin.")
+        assert proteases_in_record(r) == ["Trypsin"]
+
+
+class TestCleavageAgent:
+    def test_fabricated_enzyme_is_a_blocker(self):
+        r = rec(sampleProcessingProtocol="Tryptic digestion was performed for 50 ug protein.")
+        f = check_cleavage_agent(r, ["NT=Chymotrypsin;AC=MS:1001306"])
+        codes = {x.code for x in f}
+        # Both halves of the real defect are reported: a fabricated enzyme, and the actual
+        # enzyme missing.
+        assert "cleavage_agent_contradicted" in codes
+        assert "cleavage_agent_incomplete" in codes
+        assert BLOCKER in {x.severity for x in f}
+
+    def test_unsupported_enzyme_when_record_names_none(self):
+        f = check_cleavage_agent(rec(), ["NT=Trypsin;AC=MS:1001251"])
+        assert f and f[0].code == "cleavage_agent_unsupported"
+
+    def test_co_digest_reduced_to_one_enzyme(self):
+        r = rec(sampleProcessingProtocol=(
+            "Protein was digested with Lys-C for 4 h and subsequently with trypsin overnight."))
+        f = check_cleavage_agent(r, ["NT=Trypsin;AC=MS:1001251"])
+        assert [x.code for x in f] == ["cleavage_agent_incomplete"]
+        assert f[0].severity == MAJOR
+
+    def test_complete_co_digest_is_clean(self):
+        r = rec(sampleProcessingProtocol=(
+            "Protein was digested with Lys-C for 4 h and subsequently with trypsin overnight."))
+        assert check_cleavage_agent(
+            r, ["NT=Trypsin;AC=MS:1001251", "NT=Lys-C;AC=MS:1001309"]) == []
+
+
+class TestOrganism:
+    def test_declared_species_absent_from_the_record(self):
+        """PXD041192: PRIDE registers Homo sapiens for a murine study."""
+        r = rec(title="Therapeutic remodelling of murine heart",
+                projectDescription="Mice were given a coronary artery occlusion.")
+        f = check_organism(r, "Homo sapiens")
+        assert f and f.severity == BLOCKER
+
+    def test_passing_mention_is_not_a_contradiction(self):
+        """A human search database or ortholog must not flag a mouse deposit."""
+        r = rec(title="Mouse heart proteome",
+                dataProcessingProtocol="Searched against the human UniProt database.")
+        assert check_organism(r, "Mus musculus") is None
+
+    def test_agreement_is_clean(self):
+        assert check_organism(rec(title="Mouse heart"), "Mus musculus") is None
+
+
+class TestOrganismPart:
+    def test_title_names_adipose_not_heart(self):
+        """PXD028158: PRIDE's dropdown said Heart; the title says epicardial adipose tissue."""
+        r = rec(title="Proteomics of epicardial adipose tissue in heart failure patients")
+        f = check_organism_part(r, "heart")
+        assert any(x.code == "organism_part_contradicted" and x.severity == BLOCKER for x in f)
+
+    def test_title_names_aortic_arches(self):
+        """PXD020406: 'aortic arches' -- note plural, which a \\barch\\b pattern misses."""
+        r = rec(title="Wild-type and O/E uPA in mouse aortic arches")
+        assert any(x.code == "organism_part_contradicted" for x in check_organism_part(r, "heart"))
+
+    def test_run_names_name_a_cell_line(self):
+        """PXD045956: 22 of 66 runs are HCT116, annotated as mouse heart."""
+        runs = ["20220608_HCT116_DDA_1", "20220608_HCT116_DDA_2", "mouse_heart_1"]
+        f = check_organism_part(rec(), "heart", runs)
+        assert any(x.code == "run_names_name_a_cell_line" for x in f)
+
+    def test_run_names_name_another_organ(self):
+        """PXD051406: 22 of 42 runs are named Aorta-*."""
+        f = check_organism_part(rec(), "heart", ["Aorta-Ctr_01", "Aorta-Ctr_02", "heart_1"])
+        assert any(x.code == "run_names_name_another_organ" for x in f)
+
+    def test_cultured_material_has_no_anatomical_source(self):
+        r = rec(title="Proteome of hiPSC-derived cardiomyocytes")
+        assert any(x.code == "organism_part_from_cultured_material"
+                   for x in check_organism_part(r, "heart"))
+
+    def test_genuine_tissue_is_clean(self):
+        r = rec(title="Left ventricular tissue from eight individuals")
+        assert check_organism_part(r, "heart", ["LV_1", "LV_2"]) == []
+
+    def test_sentinel_is_never_flagged(self):
+        assert check_organism_part(rec(title="epicardial adipose"), "not available") == []
+
+
+class TestInstrument:
+    def test_vendor_cannot_write_the_format(self):
+        """PXD076291: a Thermo Q Exactive HF declared for Bruker .d files."""
+        f = check_instrument(rec(), "Q Exactive HF", ["a.d.zip", "b.d.zip"])
+        assert any(x.code == "instrument_cannot_write_these_files" and x.severity == BLOCKER
+                   for x in f)
+
+    def test_bruker_cannot_write_thermo_raw(self):
+        """PXD029649: timsTOF Pro declared over Thermo .raw files."""
+        f = check_instrument(rec(), "timsTOF Pro", ["MD131PRM1_1.raw"])
+        assert any(x.code == "instrument_cannot_write_these_files" for x in f)
+
+    def test_neutral_formats_do_not_trigger(self):
+        assert not [x for x in check_instrument(rec(), "Q Exactive HF", ["a.mzML"])
+                    if x.code == "instrument_cannot_write_these_files"]
+
+    def test_matching_vendor_is_clean(self):
+        assert check_instrument(rec(), "Q Exactive HF", ["a.raw"]) == []
+
+    def test_protocol_names_a_more_specific_model(self):
+        r = rec(sampleProcessingProtocol="Data were recorded on a Q Exactive HF-X.")
+        f = check_instrument(r, "Q Exactive", ["a.raw"])
+        assert any(x.code == "instrument_contradicted" for x in f)
+
+
+class TestDisease:
+    def test_disease_on_control_named_runs(self):
+        """PXD027772: 20 of 44 runs are SKM_WT_*, all asserting Duchenne muscular dystrophy."""
+        runs = ["SKM_DMD_1", "SKM_DMD_2", "SKM_WT_3", "SKM_WT_4"]
+        f = check_disease(rec(), "duchenne muscular dystrophy", runs)
+        assert any(x.code == "disease_on_control_runs" and x.severity == BLOCKER for x in f)
+
+    def test_control_arm_named_only_in_the_record(self):
+        """PXD055505: runs use a bare C_ prefix, but the record says 'sham group'."""
+        r = rec(projectDescription="Mice were divided into a sham group (n = 10) and an "
+                                   "ischemic group (n = 10).")
+        f = check_disease(r, "cerebrovascular disease", ["C_Brain_1", "I_Brain_1"])
+        assert any(x.code == "disease_with_control_arm_in_record" for x in f)
+
+    def test_value_that_is_not_a_disease_term(self):
+        """PXD046496: 'inflammation' resolves only to a symptom/phenotype ontology."""
+        f = check_disease(rec(), "inflammation", ["r1"])
+        assert any(x.code == "not_a_disease_term" for x in f)
+
+    def test_generic_registry_bucket(self):
+        f = check_disease(rec(), "cardiovascular system disease", ["r1"])
+        assert any(x.code == "generic_disease_bucket" for x in f)
+
+    def test_sentinel_and_normal_are_clean(self):
+        assert check_disease(rec(), "not available", ["ctrl_1"]) == []
+        assert check_disease(rec(), "normal", ["ctrl_1"]) == []
+
+    def test_specific_diagnosis_without_controls_is_clean(self):
+        assert check_disease(rec(), "dilated cardiomyopathy", ["P1", "P2"]) == []
+
+
+class TestAcquisition:
+    def test_dda_library_runs_in_a_dia_deposit(self):
+        """PXD050447: 200 of 799 runs are _DDALib_, all annotated DIA."""
+        runs = ["s_DIA_1", "s_DIA_2", "pool_DDALib_F01"]
+        declared = ["Data-independent acquisition"] * 3
+        f = check_acquisition(declared, runs)
+        assert f and f[0].severity == BLOCKER
+
+    def test_sciex_ida_is_dda(self):
+        assert acquisition_from_run_name("2018_pool_IDA_6") == "Data-dependent acquisition"
+
+    def test_prm_with_a_trailing_digit(self):
+        """PXD031424: 188 of 248 runs are *PRM1..N, annotated DDA."""
+        assert acquisition_from_run_name("AMPK-Control-Try-PRM1") == "Parallel reaction monitoring"
+
+    def test_parameter_spelling_is_understood(self):
+        f = check_acquisition(["NT=Data-independent acquisition;AC=PRIDE:0000450"],
+                              ["sample_DDA_1"])
+        assert f and f[0].code == "acquisition_contradicted_by_run_name"
+
+    def test_agreement_is_clean(self):
+        assert check_acquisition(["Data-independent acquisition"] * 2, ["a_DIA_1", "b_SWATH_2"]) == []
+
+    def test_uninformative_run_names_are_clean(self):
+        assert check_acquisition(["Data-independent acquisition"] * 2, ["1.raw", "2.raw"]) == []
+
+
+class TestLabelled:
+    def test_quantification_method_field_is_decisive(self):
+        """PXD016095: PRIDE registers 'MS1 based isotope labeling'."""
+        r = rec(quantificationMethods=["MS1 based isotope labeling"])
+        assert check_labelled(r, "NT=label free sample;AC=MS:1002038") is not None
+
+    def test_reductive_demethylation_spelling(self):
+        """PXD016095: the submitter wrote 'demethylation', not 'dimethylation'."""
+        r = rec(sampleProcessingProtocol=(
+            "Chemical labeling by reductive demethylation was performed, labeling 'light' for "
+            "wt and 'heavy' for the knockout."))
+        assert check_labelled(r, "NT=label free sample;AC=MS:1002038") is not None
+
+    def test_tmt_plex(self):
+        r = rec(sampleProcessingProtocol="Analysed with a TMT2-plex method.")
+        assert check_labelled(r, "NT=label free sample;AC=MS:1002038") is not None
+
+    def test_label_free_deposit_is_clean(self):
+        r = rec(sampleProcessingProtocol="Label-free quantification was performed.")
+        assert check_labelled(r, "NT=label free sample;AC=MS:1002038") is None
+
+    def test_declared_labelled_channel_is_not_flagged(self):
+        r = rec(quantificationMethods=["TMT"])
+        assert check_labelled(r, "NT=TMT126;AC=MS:1002623") is None
+
+
+class TestReconcileEntryPoint:
+    def _rows(self, n=2, **over):
+        base = {
+            "source name": "PXD1-Sample-1",
+            "characteristics[organism]": "Mus musculus",
+            "characteristics[organism part]": "heart",
+            "characteristics[disease]": "not available",
+            "assay name": "run1",
+            "comment[instrument]": "NT=Q Exactive HF;AC=MS:1002523",
+            "comment[cleavage agent details]": "NT=Trypsin;AC=MS:1001251",
+            "comment[proteomics data acquisition method]": "Data-dependent acquisition",
+            "comment[label]": "NT=label free sample;AC=MS:1002038",
+            "comment[data file]": "run1.raw",
+        }
+        base.update(over)
+        return [dict(base, **{"assay name": f"run{i}", "comment[data file]": f"run{i}.raw"})
+                for i in range(1, n + 1)]
+
+    def test_clean_annotation_reports_nothing(self):
+        r = rec(title="Mouse heart proteome",
+                sampleProcessingProtocol="Samples were digested with trypsin overnight.")
+        report = reconcile(r, self._rows(), "PXD000001")
+        assert report.clean, report.render()
+        assert "agrees with the deposit record" in report.render()
+
+    def test_findings_are_ordered_and_rendered(self):
+        r = rec(title="Proteomics of epicardial adipose tissue",
+                sampleProcessingProtocol="Digested with trypsin.",
+                quantificationMethods=["TMT"])
+        report = reconcile(r, self._rows(), "PXD000002")
+        assert not report.clean
+        assert report.blockers
+        assert report.render().splitlines()[0].startswith("PXD000002:")
+
+    def test_empty_rows_are_safe(self):
+        assert reconcile(rec(), [], "PXD000003").clean

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -55,6 +55,7 @@ def cmd_score(args: argparse.Namespace) -> int:
 
 def cmd_fix(args: argparse.Namespace) -> int:
     from pathlib import Path
+
     from tools.sdrf_fixer import fix_sdrf
     fixed, report = fix_sdrf(args.sdrf_file)
     print(report.changelog())
@@ -119,8 +120,9 @@ def cmd_massive_files(args: argparse.Namespace) -> int:
 
 
 def cmd_cellline(args: argparse.Namespace) -> int:
-    from tools.cellline_db import CellLineDatabase, annotate_sdrf_celllines
     from pathlib import Path
+
+    from tools.cellline_db import CellLineDatabase, annotate_sdrf_celllines
 
     if args.cellline_command == "lookup":
         db = CellLineDatabase()
@@ -194,7 +196,12 @@ def cmd_bruker_dia(args: argparse.Namespace) -> int:
     """Read DIA isolation windows out of a Bruker .d archive without downloading it."""
     import json
 
-    from tools.bruker_tdf import ZipRangeError, analyze, describe_isolation_window, render
+    from tools.bruker_tdf import (
+        ZipRangeError,
+        analyze,
+        describe_isolation_window,
+        render,
+    )
 
     try:
         acq = analyze(args.source)
@@ -211,6 +218,42 @@ def cmd_bruker_dia(args: argparse.Namespace) -> int:
     else:
         print(render(acq))
     return 0
+
+
+def cmd_reconcile(args: argparse.Namespace) -> int:
+    """Reconcile an SDRF's values against the archive record they came from."""
+    import json
+    from pathlib import Path
+
+    from tools.record_reconcile import reconcile
+
+    record = json.loads(Path(args.record).read_text(encoding="utf-8-sig"))
+    # PRIDE's /projects/{acc} endpoint nests the fields under a "project" key; the search
+    # endpoint returns them flat. Accept either.
+    if "project" in record and isinstance(record["project"], dict):
+        record = record["project"]
+
+    text = Path(args.sdrf_file).read_text(encoding="utf-8-sig")
+    lines = text.splitlines()
+    if not lines:
+        print("empty SDRF")
+        return 1
+    header = [h.strip() for h in lines[0].split("\t")]
+    rows = []
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        cells = line.split("\t")
+        row: dict[str, str] = {}
+        for name, value in zip(header, cells):
+            # A repeated column (cleavage agent, modification parameters) must not be
+            # collapsed to its last value the way csv.DictReader would.
+            row[name] = value if name not in row else f"{row[name]}|{value}"
+        rows.append(row)
+
+    report = reconcile(record, rows, accession=args.accession or "")
+    print(report.render())
+    return 1 if report.blockers else 0
 
 
 def main() -> None:
@@ -285,6 +328,16 @@ def main() -> None:
     )
     p.add_argument("review_gate_args", nargs=argparse.REMAINDER)
 
+    # reconcile
+    p = subparsers.add_parser(
+        "reconcile",
+        help="Check an SDRF's values against the deposit record's prose and run names",
+    )
+    p.add_argument("sdrf_file")
+    p.add_argument("--record", required=True,
+                   help="JSON project record from the archive (PRIDE /projects/{acc} or search)")
+    p.add_argument("--accession", default=None)
+
     # audit-existing
     p = subparsers.add_parser(
         "audit-existing",
@@ -326,6 +379,7 @@ def main() -> None:
         "review-gate": cmd_review_gate,
         "audit-existing": cmd_audit_existing,
         "bruker-dia": cmd_bruker_dia,
+        "reconcile": cmd_reconcile,
     }
 
     sys.exit(commands[args.command](args))

--- a/tools/record_reconcile.py
+++ b/tools/record_reconcile.py
@@ -1,0 +1,505 @@
+"""Reconcile an SDRF's claims against the deposit record they were supposedly derived from.
+
+A repository archive record has two kinds of metadata, and they are not equally reliable:
+
+* **structured fields** — PRIDE's ``instruments``, ``diseases``, ``organismParts`` and
+  ``organisms`` are dropdowns the submitter picked from at deposition time;
+* **prose and file names** — the title, the sample- and data-processing protocols, and the
+  names the submitter gave the deposited runs.
+
+Annotating from the structured fields alone is the single most productive source of
+*well-formed false claims* in SDRF: values that resolve in the right ontology, pass
+``parse_sdrf`` and pass a repository's review gate while saying something the deposit itself
+contradicts. In one 390-file batch this produced ``organism part = heart`` for epicardial
+adipose tissue, human HeLa QC injections annotated as mouse heart, ``Trypsin`` for a study
+that digested nothing, and a patient diagnosis on wild-type control runs.
+
+This module treats the structured field as one witness rather than the record. Every check
+returns a :class:`Finding` when the prose or the run names disagree, and ``None`` when they
+do not. Nothing here decides what to write: an annotator's correct response to a finding is
+usually a sentinel, and a sentinel is a result, not a failure.
+
+Typical use::
+
+    findings = reconcile(record, sdrf_rows)
+    for f in findings:
+        print(f)
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+
+BLOCKER = "blocker"   # the annotation contradicts the deposit
+MAJOR = "major"       # the deposit supports something more specific or more complete
+MINOR = "minor"       # worth knowing, does not misrepresent the data
+
+
+@dataclass
+class Finding:
+    code: str
+    severity: str
+    column: str
+    summary: str
+    evidence: str = ""
+
+    def __str__(self) -> str:
+        tail = f"  [{self.evidence}]" if self.evidence else ""
+        return f"{self.severity.upper():8s} {self.code} ({self.column}): {self.summary}{tail}"
+
+
+# --------------------------------------------------------------------------- text handling
+_PROSE_KEYS = ("title", "projectDescription", "sampleProcessingProtocol", "dataProcessingProtocol")
+# Abbreviations that would otherwise split a sentence in the middle of a method.
+_ABBR = [(r"(\d)\.(\d)", r"\1<DOT>\2"),
+         (r"\b(e\.g|i\.e|vs|cf|approx|ca|Fig|no|et al)\.", r"\1<DOT>"),
+         (r"(\d\s*°?\s*C)\.", r"\1<DOT>")]
+
+
+def prose(record: dict, *keys: str) -> str:
+    """The submitter's own free text, joined. Defaults to every prose field."""
+    return " ".join(str(record.get(k) or "") for k in (keys or _PROSE_KEYS))
+
+
+def sentences(text: str) -> list[str]:
+    """Split into sentences without breaking on decimals, temperatures or 'e.g.'."""
+    for pat, rep in _ABBR:
+        text = re.sub(pat, rep, text, flags=re.IGNORECASE)
+    return [s.replace("<DOT>", ".") for s in re.split(r"(?<=[.;])\s+", text) if s.strip()]
+
+
+# --------------------------------------------------------------------------- organism
+_SPECIES = [
+    (r"\bmice\b|\bmouse\b|\bmurine\b|C57BL/6|BALB/c", "Mus musculus"),
+    (r"\brats?\b|Sprague[- ]Dawley|Wistar|\bWKY\b", "Rattus norvegicus"),
+    (r"\bpigs?\b|\bporcine\b|\bswine\b", "Sus scrofa"),
+    (r"\bbovine\b|\bcows?\b|\bcattle\b", "Bos taurus"),
+    (r"\brabbits?\b", "Oryctolagus cuniculus"),
+    (r"\bzebrafish\b", "Danio rerio"),
+    (r"\bhumans?\b|\bhuman-derived\b", "Homo sapiens"),
+]
+
+
+def check_organism(record: dict, declared: str) -> Finding | None:
+    """Flag a declared organism the prose never mentions while naming exactly one other.
+
+    Deliberately conservative. A species is mentioned in passing in almost every study —
+    a human ortholog, a human search database, human disease context — so a contradiction
+    is only reported when the declared species appears *nowhere* in the text.
+    """
+    text = prose(record, "title", "projectDescription", "sampleProcessingProtocol")
+    named = {sp for pat, sp in _SPECIES if re.search(pat, text, re.IGNORECASE)}
+    if len(named) != 1:
+        return None
+    only = next(iter(named))
+    if only == declared or declared.startswith(only.split()[0]):
+        return None
+    declared_pat = next((pat for pat, sp in _SPECIES if sp == declared), None)
+    if declared_pat and re.search(declared_pat, text, re.IGNORECASE):
+        return None
+    return Finding("organism_contradicted", BLOCKER, "characteristics[organism]",
+                   f"the record names only {only} and never {declared}",
+                   f"declared {declared!r}")
+
+
+# --------------------------------------------------------------------------- organism part
+# Tissues a keyword sweep confuses with the organ it was searching for. Each pairing below
+# was an observed false positive where the structured field said one thing and the title
+# said another.
+_TITLE_TISSUE = [
+    ((r"\b(epicardial|pericardial|mediastinal|perivascular|subcutaneous|visceral)"
+      r"\s+(adipose|fat)\b|\bEAT\b(?!\w)"), "adipose tissue"),
+    (r"\baortic\s+(arch(es)?|aneurysm|root)\b|\babdominal aortic aneurysm\b", "aorta"),
+    (r"\bcarotid\b.{0,20}\b(plaque|artery)\b", "carotid artery"),
+    (r"\bpericardial fluid\b", "pericardial fluid"),
+]
+# Material with an anatomical *identity* but no anatomical *source*. An iPSC-derived
+# cardiomyocyte was never part of a heart; a purified recombinant protein was never a tissue.
+_NO_SOURCE = re.compile(
+    r"\bhiPSC|\biPSC\b|induced pluripotent|\bhPSC\b|embryonic stem cell|immortali[sz]ed|"
+    r"\bcell line\b|recombinant|purified\s+\w+\s+protein", re.IGNORECASE)
+# Run-name tokens that name the material directly.
+_RUN_TISSUE = [
+    (r"(^|[_\-. ])aorta", "aorta"), (r"(^|[_\-. ])(carotid|plaque)", "carotid artery"),
+    (r"(^|[_\-. ])(liver|hepat)", "liver"), (r"(^|[_\-. ])(kidney|renal)", "kidney"),
+    (r"(^|[_\-. ])(brain|cortex|cerebell)", "brain"), (r"(^|[_\-. ])lung", "lung"),
+    (r"(^|[_\-. ])spleen", "spleen"), (r"(^|[_\-. ])(skeletal|quadriceps|gastrocnem|soleus)",
+                                       "skeletal muscle"),
+    (r"(^|[_\-. ])(adipose|fat)([_\-. ]|$)", "adipose tissue"),
+]
+_CELL_LINE_RUN = re.compile(
+    r"(^|[_\-. ])(hela|hct116|hek\s?-?293|hepg2|jurkat|k562|thp-?1|c2c12|h9c2|hl-?1)", re.IGNORECASE)
+
+
+def check_organism_part(record: dict, declared: str,
+                        run_names: Sequence[str] = ()) -> list[Finding]:
+    """Flag an organism part the title, the material class or the run names contradict."""
+    out: list[Finding] = []
+    if not declared or declared.lower() in ("not available", "not applicable"):
+        return out
+    title = prose(record, "title", "projectDescription")
+    for pat, what in _TITLE_TISSUE:
+        if re.search(pat, title, re.IGNORECASE):
+            m = re.search(pat, title, re.IGNORECASE)
+            out.append(Finding("organism_part_contradicted", BLOCKER,
+                               "characteristics[organism part]",
+                               f"the title names {what}, but the annotation says {declared!r}",
+                               m.group(0).strip()))
+            break
+    if _NO_SOURCE.search(title):
+        m = _NO_SOURCE.search(title)
+        out.append(Finding("organism_part_from_cultured_material", MAJOR,
+                           "characteristics[organism part]",
+                           "cultured, engineered or purified material has an anatomical "
+                           "identity but no anatomical source",
+                           m.group(0).strip()))
+    lines = [n for n in run_names if _CELL_LINE_RUN.search(n)]
+    if lines:
+        out.append(Finding("run_names_name_a_cell_line", BLOCKER,
+                           "characteristics[organism part]",
+                           f"{len(lines)} of {len(run_names)} run names name an immortalised "
+                           f"cell line, not the annotated tissue", lines[0]))
+    for pat, what in _RUN_TISSUE:
+        hits = [n for n in run_names if re.search(pat, n, re.IGNORECASE)]
+        if hits and what.split()[0].lower() not in declared.lower():
+            out.append(Finding("run_names_name_another_organ", BLOCKER,
+                               "characteristics[organism part]",
+                               f"{len(hits)} of {len(run_names)} run names name {what}, "
+                               f"but every row says {declared!r}", hits[0]))
+            break
+    return out
+
+
+# --------------------------------------------------------------------------- instrument
+_INSTRUMENT_PROSE = [
+    (r"Q[\s-]?Exactive\s*HF[\s-]?X|Q[\s-]?Exactive\s*HFX", "Q Exactive HF-X"),
+    (r"Q[\s-]?Exactive\s*HF\b", "Q Exactive HF"),
+    (r"Q[\s-]?Exactive\s*Plus|QExactivePlus", "Q Exactive Plus"),
+    (r"Orbitrap\s*Exploris\s*480|Exploris\s*480", "Orbitrap Exploris 480"),
+    (r"Orbitrap\s*Exploris\s*240|Exploris\s*240", "Orbitrap Exploris 240"),
+    (r"Orbitrap\s*Astral\s*Zoom", "Orbitrap Astral Zoom"),
+    (r"Orbitrap\s*Ascend", "Orbitrap Ascend"),
+    (r"Orbitrap\s*Eclipse", "Orbitrap Eclipse"),
+    (r"Fusion\s*Lumos", "Orbitrap Fusion Lumos"),
+    (r"LTQ\s*Orbitrap\s*XL", "LTQ Orbitrap XL"),
+    (r"Orbitrap\s*Velos\s*Pro", "Orbitrap Velos Pro"),
+    (r"timsTOF\s*SCP", "timsTOF SCP"),
+    (r"timsTOF\s*Pro\s*2", "timsTOF Pro 2"),
+    (r"timsTOF\s*Pro", "timsTOF Pro"),
+    (r"TripleTOF\s*6600", "TripleTOF 6600"),
+    (r"TripleTOF\s*5600\s*\+", "TripleTOF 5600+"),
+]
+# A vendor's acquisition software writes its own container format. This is the one check in
+# the module that needs no prose at all and admits no judgement.
+_VENDOR_OF = [
+    (r"orbitrap|q exactive|ltq|exploris|astral|velos|lcq|fusion|lumos|ascend", "thermo"),
+    (r"timstof|maxis|impact|amazon|hct|ultraflex|autoflex", "bruker"),
+    (r"triplet?of|qstar|q trap|x500|zenotof", "sciex"),
+    (r"synapt|xevo", "waters"),
+]
+_VENDOR_EXT = {
+    "thermo": (".raw", ".raw.zip"),
+    "bruker": (".d", ".d.zip", ".d.7z", ".d.tar", ".baf", ".yep", ".tdf", ".fid"),
+    "sciex": (".wiff", ".wiff.zip"),
+    "waters": (".raw", ".raw.zip"),
+}
+_NEUTRAL_EXT = (".mzml", ".mzxml", ".mgf")
+
+
+def _vendor(model: str) -> str | None:
+    low = model.lower()
+    return next((v for pat, v in _VENDOR_OF if re.search(pat, low)), None)
+
+
+def check_instrument(record: dict, declared_model: str,
+                     data_files: Sequence[str] = ()) -> list[Finding]:
+    """Flag an instrument the prose contradicts, or that cannot have written the files."""
+    out: list[Finding] = []
+    text = prose(record)
+    for pat, model in _INSTRUMENT_PROSE:
+        if re.search(pat, text, re.IGNORECASE):
+            if model.lower() != declared_model.lower():
+                m = re.search(pat, text, re.IGNORECASE)
+                out.append(Finding("instrument_contradicted", MAJOR, "comment[instrument]",
+                                   f"the protocol names {model!r}, the annotation says "
+                                   f"{declared_model!r}", m.group(0).strip()))
+            break
+    vendor = _vendor(declared_model)
+    if vendor and data_files:
+        allowed = set(_VENDOR_EXT[vendor]) | set(_NEUTRAL_EXT)
+        every = sorted({e for exts in _VENDOR_EXT.values() for e in exts} | set(_NEUTRAL_EXT),
+                       key=len, reverse=True)
+        seen = {next((e for e in every if f.lower().endswith(e)), None) for f in data_files}
+        seen.discard(None)
+        if seen and not (seen & allowed):
+            out.append(Finding("instrument_cannot_write_these_files", BLOCKER,
+                               "comment[instrument]",
+                               f"{declared_model} is a {vendor} instrument and cannot produce "
+                               f"{'/'.join(sorted(seen))} files", data_files[0]))
+    return out
+
+
+# --------------------------------------------------------------------------- disease
+_CONTROL_RUN = re.compile(
+    r"(^|[_\-. ])(wt|ctrl|ctl|ctr|control|sham|scr|scramble|untreated|vehicle|veh|"
+    r"naive|healthy|normal|nc|mock|blank|pbs|dmso|nonfailing|non-failing)([_\-. 0-9]|$)", re.IGNORECASE)
+_CONTROL_PROSE = re.compile(
+    r"\bsham(-operated)?\b|\bwild[- ]?type\b|\bcontrol (group|animals?|subjects?|samples?|arm|"
+    r"mice|rats?)\b|\bhealthy (donors?|subjects?|controls?|volunteers?)\b|\bnon-?failing\b|"
+    r"\bnormoxi|\bvehicle\b|\buntreated\b|\bplacebo\b|\bcontrols?\s*\(n\s*=", re.IGNORECASE)
+# Registry buckets rather than diagnoses, and values that are not disease terms at all.
+GENERIC_DISEASE = {"cardiovascular system disease", "heart disease", "cardiovascular disorder",
+                   "disease", "cardiomyopathy", "cancer", "neoplasm"}
+NON_DISEASE = {"inflammation", "mixed disorder as reaction to stress"}
+
+
+def check_disease(record: dict, declared: str,
+                  run_names: Sequence[str] = ()) -> list[Finding]:
+    """Flag a project-level diagnosis asserted per sample, on controls, or not a disease."""
+    out: list[Finding] = []
+    value = (declared or "").strip().lower()
+    if not value or value in ("not available", "not applicable", "normal"):
+        return out
+    if value in NON_DISEASE:
+        out.append(Finding("not_a_disease_term", MAJOR, "characteristics[disease]",
+                           f"{declared!r} has no term in a disease ontology "
+                           f"(EFO/MONDO/DOID); it is a symptom or phenotype"))
+    elif value in GENERIC_DISEASE:
+        out.append(Finding("generic_disease_bucket", MINOR, "characteristics[disease]",
+                           f"{declared!r} is a registry bucket, not a diagnosis; the record "
+                           f"title usually names the actual condition"))
+    controls = [n for n in run_names if _CONTROL_RUN.search(n)]
+    if controls:
+        out.append(Finding("disease_on_control_runs", BLOCKER, "characteristics[disease]",
+                           f"{len(controls)} of {len(run_names)} run names mark a control arm, "
+                           f"but every row asserts {declared!r}", controls[0]))
+    elif run_names:
+        m = _CONTROL_PROSE.search(prose(record))
+        if m:
+            out.append(Finding("disease_with_control_arm_in_record", MAJOR,
+                               "characteristics[disease]",
+                               f"the record describes a control arm, so {declared!r} cannot "
+                               f"hold for every row", m.group(0).strip()))
+    return out
+
+
+# --------------------------------------------------------------------------- acquisition
+_DDA_RUN = re.compile(r"(^|[_\-.])(dda|ida|ddalib|dda[_\-]?lib)([_\-.]|$)", re.IGNORECASE)
+_DIA_RUN = re.compile(r"(^|[_\-.])(dia|swath|diapasef|udmse|hdmse|mse)([_\-.]|$)", re.IGNORECASE)
+_PRM_RUN = re.compile(r"(^|[_\-.])(prm|srm|mrm)\d*([_\-.]|$)", re.IGNORECASE)
+
+
+def acquisition_from_run_name(run_name: str) -> str | None:
+    """The mode the submitter encoded in the run's own name, if any."""
+    if _PRM_RUN.search(run_name):
+        return "Parallel reaction monitoring"
+    dda, dia = _DDA_RUN.search(run_name), _DIA_RUN.search(run_name)
+    if dda and not dia:
+        return "Data-dependent acquisition"
+    if dia and not dda:
+        return "Data-independent acquisition"
+    return None
+
+
+def check_acquisition(declared_per_row: Sequence[str],
+                      run_names: Sequence[str]) -> list[Finding]:
+    """Flag rows whose acquisition mode their own run name contradicts.
+
+    A DIA deposit normally also contains the DDA runs that built its spectral library. One
+    value for the whole file mislabels them.
+    """
+    bad: list[tuple[str, str, str]] = []
+    for value, name in zip(declared_per_row, run_names):
+        from_name = acquisition_from_run_name(name)
+        written = re.sub(r"^NT=|;AC=.*$", "", value or "")
+        if from_name and written and from_name.lower() != written.lower():
+            bad.append((name, written, from_name))
+    if not bad:
+        return []
+    name, written, expected = bad[0]
+    return [Finding("acquisition_contradicted_by_run_name", BLOCKER,
+                    "comment[proteomics data acquisition method]",
+                    f"{len(bad)} of {len(run_names)} rows say {written!r} while the run name "
+                    f"says {expected!r}", name)]
+
+
+# --------------------------------------------------------------------------- cleavage agent
+_DIGEST_CUE = re.compile(
+    r"digest\w*|proteolytic|in-?gel|in-?solution|FASP|SP3|1\s*:\s*\d+\s*\(?w/w|"
+    r"enzyme[- ]to[- ]protein|overnight at 37|incubated with|"
+    r"enzyme\s+(specificity|was|used)|specificity\s+(was|of)|enzymes?\s+such as|"
+    r"as the (proteolytic )?enzyme|cleav\w+\s+(agent|specificity)", re.IGNORECASE)
+# The protease name is the analyte, a proteasome activity readout, an inhibitor or a
+# contaminant-database entry rather than the reagent that produced the peptides.
+_PROTEASE_ROLE_EXCLUDE = re.compile(
+    r"chymotrypsin-?like|trypsin-?like|caspase-?like|presence of|\blevels\b|inhibitor|"
+    r"\bactivity\b|cleavage sites by|contaminant|\bcRAP\b|western|elisa|immunoblot|"
+    r"abundance of", re.IGNORECASE)
+_PROTEASES = [
+    (r"\btryps(in|inis|iniz)\w*\b|\btryptic\b", "Trypsin"),
+    (r"\blys\s*-?\s*c\b|lysyl\s*endopeptidase|endoproteinase\s+lys-?c", "Lys-C"),
+    (r"\bchymotryps\w*\b", "Chymotrypsin"),
+    (r"\bglu\s*-?\s*c\b|endoproteinase\s+glu-?c|\bv8\s+protease", "glutamyl endopeptidase"),
+    (r"\basp\s*-?\s*n\b", "Asp-N"),
+    (r"\barg\s*-?\s*c\b", "Arg-C"),
+    (r"lysargin[ae]se", "LysargiNase"),
+]
+
+
+def proteases_in_record(record: dict) -> list[str]:
+    """Proteases the record names as *digest reagents*, in the module's fixed order.
+
+    Evidence is scoped to the sentence. A character window bleeds across boundaries — so
+    "…responsible for digestion. Western analysis shows that trypsin in plasma is elevated…"
+    reads as a digest — and truncates sequential digests, where the second enzyme sits far
+    from the single "digested with".
+    """
+    found: list[str] = []
+    for sentence in sentences(prose(record)):
+        if not _DIGEST_CUE.search(sentence) or _PROTEASE_ROLE_EXCLUDE.search(sentence):
+            continue
+        for pat, label in _PROTEASES:
+            if label not in found and re.search(pat, sentence, re.IGNORECASE):
+                found.append(label)
+    return found
+
+
+def check_cleavage_agent(record: dict, declared: Iterable[str]) -> list[Finding]:
+    """Flag a protease the record does not support, or a co-digest reduced to one enzyme."""
+    written = [re.sub(r"^NT=|;AC=.*$", "", d or "").strip() for d in declared]
+    written = [w for w in written if w]
+    supported = proteases_in_record(record)
+    out: list[Finding] = []
+    if not supported:
+        if written:
+            out.append(Finding("cleavage_agent_unsupported", BLOCKER,
+                               "comment[cleavage agent details]",
+                               f"the record never names {', '.join(written)} as a digest "
+                               f"reagent; the annotation may have matched the enzyme in "
+                               f"another role"))
+        return out
+    for w in written:
+        if w.lower() not in {s.lower() for s in supported}:
+            out.append(Finding("cleavage_agent_contradicted", BLOCKER,
+                               "comment[cleavage agent details]",
+                               f"the annotation says {w!r} but the record's digest names "
+                               f"{', '.join(supported)}"))
+    missing = [s for s in supported if s.lower() not in {w.lower() for w in written}]
+    if missing and written:
+        out.append(Finding("cleavage_agent_incomplete", MAJOR,
+                           "comment[cleavage agent details]",
+                           f"the record names a {'/'.join(supported)} digest but only "
+                           f"{', '.join(written)} is declared",
+                           f"missing: {', '.join(missing)}"))
+    return out
+
+
+# --------------------------------------------------------------------------- labelling
+_LABELLED = re.compile(
+    r"\bSILAC\b|\bTMT\s?pro\b|\bTMT\s?\d*\s?-?\s?plex\b|\bTMT\b\s*(label|reagent|tag|method)|"
+    r"\biTRAQ\b|isobaric\s+(label|tag|mass tag)|tandem mass tag|"
+    r"reductive\s+d[ei]methylation|d[ei]methyl\s+label|dimethyl\s+labell?ing|"
+    r"\bICAT\b|OxICAT|\bmTRAQ\b|MS1[- ]based isotope label|reporter ion (ms2|ms3|quantif)|"
+    r"heavy lysine|\bLys8\b|\bArg10\b|1[45]N[- ]label|\b18O\b\s*(water|label)", re.IGNORECASE)
+_LABELLED_QUANT = re.compile(
+    r"\bSILAC\b|\bTMT\b|\biTRAQ\b|dimethyl|\bICAT\b|isobaric|tandem mass tag|"
+    r"MS1 based isotope label", re.IGNORECASE)
+
+
+def check_labelled(record: dict, declared_label: str = "") -> Finding | None:
+    """Flag a labelled deposit annotated as label-free.
+
+    A labelled run carries several samples in one file. Annotating it label-free asserts a
+    one-to-one run-to-sample relation the data does not have, which is why this is a blocker
+    even though every value involved is a valid CV term.
+    """
+    if declared_label and "label free" not in declared_label.lower():
+        return None
+    for method in record.get("quantificationMethods") or []:
+        if _LABELLED_QUANT.search(str(method)):
+            return Finding("labelled_annotated_as_label_free", BLOCKER, "comment[label]",
+                           "the record registers a labelled quantification method",
+                           f"quantificationMethods = {method!r}")
+    match = _LABELLED.search(prose(record))
+    if match:
+        return Finding("labelled_annotated_as_label_free", BLOCKER, "comment[label]",
+                       "the protocol describes isotope or isobaric labelling",
+                       match.group(0))
+    return None
+
+
+# --------------------------------------------------------------------------- entry point
+@dataclass
+class ReconcileReport:
+    accession: str = ""
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def blockers(self) -> list[Finding]:
+        return [f for f in self.findings if f.severity == BLOCKER]
+
+    @property
+    def clean(self) -> bool:
+        return not self.findings
+
+    def render(self) -> str:
+        if self.clean:
+            return (f"{self.accession or 'SDRF'}: every annotated value agrees with the "
+                    f"deposit record.")
+        head = (f"{self.accession or 'SDRF'}: {len(self.findings)} value(s) disagree with the "
+                f"deposit record:")
+        order = {BLOCKER: 0, MAJOR: 1, MINOR: 2}
+        return "\n".join([head, ""] +
+                         [f"  {f}" for f in sorted(self.findings, key=lambda f: order[f.severity])])
+
+
+def reconcile(record: dict, rows: Sequence[dict], accession: str = "") -> ReconcileReport:
+    """Reconcile an SDRF's values against the deposit record.
+
+    ``record`` is the archive's project metadata (PRIDE's ``/projects/{acc}`` shape or the
+    search record; only the prose keys and ``quantificationMethods`` are read). ``rows`` are
+    the SDRF data rows as dictionaries. Repeated columns should be pre-collapsed by the
+    caller, since a plain ``csv.DictReader`` keeps only the last value for a repeated name.
+    """
+    report = ReconcileReport(accession=accession)
+    if not rows:
+        return report
+
+    def col(name: str) -> list[str]:
+        return [str(r.get(name) or "") for r in rows]
+
+    runs = [r.get("assay name") or r.get("comment[data file]") or "" for r in rows]
+    files = col("comment[data file]")
+
+    organism = next((v for v in col("characteristics[organism]") if v), "")
+    if organism:
+        found = check_organism(record, organism)
+        if found:
+            report.findings.append(found)
+
+    part = next((v for v in col("characteristics[organism part]") if v), "")
+    report.findings += check_organism_part(record, part, runs)
+
+    instrument = next((v for v in col("comment[instrument]") if v), "")
+    if instrument:
+        model = re.sub(r"^NT=|;AC=.*$", "", instrument).strip()
+        report.findings += check_instrument(record, model, files)
+
+    disease = next((v for v in col("characteristics[disease]") if v), "")
+    report.findings += check_disease(record, disease, runs)
+
+    report.findings += check_acquisition(
+        col("comment[proteomics data acquisition method]"), runs)
+
+    cleavage = [v for v in col("comment[cleavage agent details]") if v]
+    if cleavage:
+        report.findings += check_cleavage_agent(record, set(cleavage))
+
+    label = next((v for v in col("comment[label]") if v), "")
+    found = check_labelled(record, label)
+    if found:
+        report.findings.append(found)
+
+    return report

--- a/tools/record_reconcile.py
+++ b/tools/record_reconcile.py
@@ -82,22 +82,42 @@ _SPECIES = [
 ]
 
 
+# A species name inside a reagent is not the study organism. "modified porcine trypsin",
+# "bovine serum albumin" and "goat anti-rabbit IgG" are the common offenders.
+_SPECIES_AS_REAGENT = re.compile(
+    r"(porcine|bovine|rabbit|goat|sheep|horse|mouse|murine|human)\s+"
+    r"(trypsin|serum albumin|BSA|serum|IgG|anti-|antibod|albumin|insulin|"
+    r"gelatin|collagen|fibronectin|thrombin)", re.IGNORECASE)
+
+
 def check_organism(record: dict, declared: str) -> Finding | None:
     """Flag a declared organism the prose never mentions while naming exactly one other.
 
-    Deliberately conservative. A species is mentioned in passing in almost every study —
-    a human ortholog, a human search database, human disease context — so a contradiction
-    is only reported when the declared species appears *nowhere* in the text.
+    Deliberately conservative, and silent wherever it cannot judge:
+
+    * the declared organism is outside this module's small species vocabulary — its absence
+      from the text then carries no information, and reporting would flag every yeast,
+      bacterial or plant deposit;
+    * the prose names several species, or none;
+    * the only species named appears in a reagent (``modified porcine trypsin``) rather than
+      as the material under study.
+
+    A species is mentioned in passing in almost every study — a human ortholog, a human
+    search database, human disease context — so a contradiction is only reported when the
+    declared species appears *nowhere* in the text.
     """
+    declared_pat = next((pat for pat, sp in _SPECIES if sp == declared), None)
+    if declared_pat is None:
+        return None
     text = prose(record, "title", "projectDescription", "sampleProcessingProtocol")
+    text = _SPECIES_AS_REAGENT.sub(" ", text)
     named = {sp for pat, sp in _SPECIES if re.search(pat, text, re.IGNORECASE)}
     if len(named) != 1:
         return None
     only = next(iter(named))
     if only == declared or declared.startswith(only.split()[0]):
         return None
-    declared_pat = next((pat for pat, sp in _SPECIES if sp == declared), None)
-    if declared_pat and re.search(declared_pat, text, re.IGNORECASE):
+    if re.search(declared_pat, text, re.IGNORECASE):
         return None
     return Finding("organism_contradicted", BLOCKER, "characteristics[organism]",
                    f"the record names only {only} and never {declared}",


### PR DESCRIPTION
@ypriverol — this one is tooling rather than datasets, so it needs your call on whether the approach is right for the plugin.

## The problem

`parse_sdrf` checks that a value is a **well-formed term in the right ontology**. It cannot check whether the value is **true of the deposit**. Those are different questions, and the second one is where annotation actually goes wrong.

I recently put a 390-file cardiac batch through an independent adversarial review — ten reviewers, fresh context, working from the deposits and their publications rather than from my notes. Every file passed `parse_sdrf`, this org's review gate (`sdrf_review.py`) and CodeRabbit. The review still found, among others:

| Written | The deposit says |
|---|---|
| `organism part = heart` | title: *"Proteomics of **epicardial adipose tissue** in heart failure patients"* (PRIDE's `organismParts` dropdown said `Heart`) |
| `organism part = heart`, 176 rows | title: *"…in mouse **aortic arches**"* |
| mouse `heart`, all 66 rows | 22 runs are named `20220608_**HCT116**_DDA_*` — a human colon-cancer line |
| `Trypsin` | a plasma **peptidomics** study with no digestion step; "trypsin" appears only as the analyte: *"the presence of **pancreatic trypsin**"* |
| `Chymotrypsin` | *"the UPS showed a higher **chymotrypsin-like activity**"* — a proteasome assay. The real digest, *"**Tryptic** digestion"*, was missed because `\btrypsin` does not match `tryptic` |
| `duchenne muscular dystrophy` on all 44 rows, as the sole `factor value` | 20 of the runs are named `SKM_**WT**_*` |
| `Q Exactive HF` (Thermo) | the deposited files are `.d.zip` (Bruker), and the protocol names a timsTOF Pro |

Every one of those is a **valid CV term making a false statement**, which is exactly the class our validators cannot see — and a wrong specific value is worse for reuse than a blank, because a consumer has no way to tell.

They all trace to one habit: reading the archive's **structured fields** (`instruments`, `diseases`, `organismParts`, `organisms`) as if they were the record. They are dropdowns the submitter picked at deposition time. In almost every case above, the contradicting evidence was sitting in the same JSON — usually in the title.

## What this adds

`tools/record_reconcile.py` treats the dropdown as one witness among several and reports where the title, the protocol prose or the run names disagree. It decides nothing: each finding is a question to answer from the record, and the right answer is usually a sentinel.

```
$ python -m tools reconcile PXD028158.sdrf.tsv --record pride_record.json --accession PXD028158
PXD028158: 2 value(s) disagree with the deposit record:

  BLOCKER  organism_part_contradicted (characteristics[organism part]):
           the title names adipose tissue, but the annotation says 'heart'  [epicardial adipose]
  MINOR    generic_disease_bucket (characteristics[disease]): 'cardiovascular system disease'
           is a registry bucket, not a diagnosis
```

Checks: organism, organism part (title, material class, run names), instrument (prose + **vendor vs file format**), disease (control arms, non-disease terms, registry buckets), acquisition mode (per-run `DDA`/`IDA`/`SWATH`/`PRM` tokens), cleavage agent (digest role + co-digests), and labelled-annotated-as-label-free.

Two design points worth your view:

- **Protease evidence is scoped to the sentence and requires a positive digest cue.** A character window bleeds across boundaries — *"…responsible for digestion. Western analysis shows that trypsin in plasma is elevated…"* reads as a digest — and it truncates sequential digests where the second enzyme sits far from the single "digested with". A blacklist cannot enumerate phrasings like *"the trypsin has a significantly elevated activity"*.
- **The vendor/file-format check needs no prose and admits no judgement.** A Bruker instrument writes `.d`, a Thermo writes `.raw`, a SCIEX writes `.wiff`. It found exactly 2 contradictions in 390 files with zero false positives. If you want only one thing from this PR, I would argue for that check — it is ~30 lines and could go straight into `sdrf_review.py` as a hard gate.

## Scope and testing

- `tools/record_reconcile.py` (new, 505 lines), `tests/test_record_reconcile.py` (new, 47 tests), a `reconcile` subcommand in `tools/cli.py`, and a required Step 8.5 plus four new rules in `skills/sdrf-annotate/SKILL.md`.
- **Every test is a defect observed in a real batch**, with the accession named in the docstring, so the tests double as the rationale.
- `323 passed` on the full suite; `ruff` clean on the changed files. No existing behaviour is modified — this is additive.
- The heuristics are deliberately conservative and fail *closed*: a species mentioned in passing does not flag a contradiction, a sentinel is never flagged, and uninformative run names produce nothing.

## What I am not claiming

The tissue and species vocabularies are seeded from what a cardiac sweep actually turned up, so they are a starting set rather than complete. If you would rather this landed as a narrower PR — say, the vendor/format check and the protease role-checking only, which are the two least judgement-laden parts — I am happy to cut it down.

Related: this is the same class of bug as the `icat`-matching-inside-`quantifi(cat)ion` issue, which also silently excluded ~99 zebrafish/yeast deposits from #274 by treating label-free records as labelled. Happy to open that recovery separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SDRF-to-project reconciliation to compare annotations with project records, run names, file formats, and instrument details.
  - Added a `reconcile` command that produces a validation report and returns a failure status when blocking inconsistencies are found.
  - Added checks for organism, tissue, disease, acquisition method, cleavage agent, and labelling annotations.

- **Documentation**
  - Added guidance for reconciliation workflows, blocker handling, sentinel values, and manual review requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->