### PR TITLE
Add .claude-plugin/marketplace.json for /plugin marketplace add

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "sdrf-skills",
+  "owner": {
+    "name": "Yasset Perez-Riverol"
+  },
+  "metadata": {
+    "description": "SDRF annotation skills - expert-level proteomics metadata workflows for AI assistants",
+    "version": "0.2.0"
+  },
+  "plugins": [
+    {
+      "name": "sdrf-skills",
+      "source": "./",
+      "description": "SDRF annotation skills - expert-level proteomics metadata workflows for AI assistants",
+      "version": "0.2.0",
+      "author": {
+        "name": "Yasset Perez-Riverol"
+      },
+      "keywords": [
+        "sdrf",
+        "proteomics",
+        "pride",
+        "metadata",
+        "annotation"
+      ],
+      "category": "domain-specific"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -62,10 +62,18 @@ Update the bundled spec any time with `git submodule update --remote --recursive
 
 <details><summary>Claude Code (plugin)</summary>
 
+**Recommended: run from a working tree**
 ```bash
 cd sdrf-skills && claude --plugin-dir .   # loads skills from the working tree
 ```
-Start from the repo root (skills reference `spec/` by repo-root-relative path). Then run `/sdrf:setup`, and use `/sdrf:annotate PXD######` or `/sdrf:validate your_file.sdrf.tsv`. Marketplace install is not available yet — see [#27](https://github.com/bigbio/sdrf-skills/issues/27).
+Start from the repo root (skills reference `spec/` by repo-root-relative path). Then run `/sdrf:setup`, and use `/sdrf:annotate PXD######` or `/sdrf:validate your_file.sdrf.tsv`.
+
+**Marketplace install** (this repo is also a marketplace as of `.claude-plugin/marketplace.json`):
+```bash
+/plugin marketplace add bigbio/sdrf-skills
+/plugin install sdrf-skills@sdrf-skills
+```
+Caveat: several skills (e.g. `/sdrf:annotate`) reference `spec/` by a path relative to the repo root. A marketplace install copies the plugin into Claude Code's plugin cache, so those repo-root-relative reads may not resolve correctly there yet — the skills would need to resolve `spec/` via `${CLAUDE_PLUGIN_ROOT}` instead. Until that's done, prefer `--plugin-dir` for full functionality; the marketplace path is offered for discovery/installability, tracked further at [#27](https://github.com/bigbio/sdrf-skills/issues/27).
 </details>
 
 <details><summary>Cursor</summary>


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json`, the manifest `/plugin marketplace add bigbio/sdrf-skills` actually needs. The repo previously had only `.claude-plugin/plugin.json` (a plugin manifest), which is not sufficient for a marketplace add - this is the concrete gap #27 identified under "Distribution" but left unaddressed (that issue scoped its own fix to README wording only).
- Updates the Claude Code section of README.md to document the two-step marketplace install (`marketplace add` then `install sdrf-skills@sdrf-skills`) alongside the existing `--plugin-dir` dev-tree method.

## Known limitation, flagged rather than silently left
Several skills (e.g. `/sdrf:annotate`) read `spec/` by a path relative to the repo root. `--plugin-dir` keeps cwd at the repo root, so this resolves fine. A marketplace install copies the plugin into Claude Code's plugin cache instead, where a bare `spec/...` read may not resolve the same way. Making that fully work needs the skills to resolve `spec/` via `${CLAUDE_PLUGIN_ROOT}` rather than a bare relative path - that's a separate, larger change across multiple SKILL.md files, out of scope for this PR. README calls this out explicitly and still recommends `--plugin-dir` for full functionality in the meantime.

## Test plan
- [x] `.claude-plugin/marketplace.json` validated as well-formed JSON
- [x] Structure matches the working pattern of other installed marketplaces (single-plugin repo, `source: "./"`), cross-checked against two live examples
- [ ] Maintainer: confirm `/plugin marketplace add bigbio/sdrf-skills` && `/plugin install sdrf-skills@sdrf-skills` succeeds end-to-end in a real Claude Code session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added marketplace registration for the SDRF Skills plugin, including its proteomics metadata workflow description and discovery keywords.
  - Added support for installing the plugin through the marketplace.

- **Documentation**
  - Updated setup guidance to recommend the working-tree approach.
  - Added marketplace installation commands and clarified when to use the plugin directory option due to path resolution limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->