### PR TITLE
Fix documented slash-command addresses: /sdrf-skills:sdrf-<name>, not /sdrf:<name>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ is **not** stored here; it is read at runtime from the `spec/` git submodule.
 Skills are auto-discovered — `.claude-plugin/plugin.json` carries no `skills` key, so Claude Code
 scans the `skills/` directory automatically. Each SKILL.md declares its own name and routing
 description in frontmatter. Currently 20: 18 domain skills
-named `sdrf:*` (invoked `/sdrf:annotate`) plus 2 review-gate skills named `sdrf-adversarial-review`
-and `sdrf-annotate-reviewed`, deliberately platform-portable rather than `/sdrf:`-namespaced.
+named `sdrf-*` (invoked as `/sdrf-skills:sdrf-annotate` etc. once installed as a marketplace plugin) plus 2 review-gate skills named `sdrf-adversarial-review`
+and `sdrf-annotate-reviewed`, deliberately platform-portable rather than plugin-namespaced.
 Run `ls skills/` for the current set — **do not trust a hardcoded skill count anywhere in this repo**;
 README.md alone carries three contradictory numbers, and commit `d5c4c70` exists only to repair drift.
 
@@ -89,7 +89,7 @@ supported local-dev flow is `claude --plugin-dir <path>`, which loads skills fro
 
 ```yaml
 ---
-name: sdrf:annotate          # namespaced; does NOT match the directory (skills/sdrf-annotate/)
+name: sdrf-annotate           # matches the directory (skills/sdrf-annotate/); invoked as /sdrf-skills:sdrf-annotate once installed as a marketplace plugin
 description: Use when the user wants to ... Triggers on ...   # always starts "Use when the user"
 user-invocable: true
 argument-hint: "[PXD accession or experiment description]"
@@ -232,7 +232,7 @@ reimplementing merge semantics.
    constraint set (column licensing + reserved-word `allow_*`), resolve with
    `spec/scripts/resolve_templates.py` — parse_sdrf enforces neither. `parse_sdrf` ships in
    `sdrf-pipelines` and is **not installed by default** (CI installs only `requests`, `pytest`,
-   `fastmcp`, `httpx` — not `sdrf-pipelines[ontology]`, which is heavy) — run `/sdrf:setup`. Keep
+   `fastmcp`, `httpx` — not `sdrf-pipelines[ontology]`, which is heavy) — run `/sdrf-skills:sdrf-setup`. Keep
    concurrent `parse_sdrf` jobs ≤ 2.
 8. **A producer must never approve its own SDRF.** For changed SDRFs, require a passing receipt from
    `sdrf-adversarial-review`; any edit invalidates the receipt and requires a fresh reviewer.

--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ Sixteen skills, most in the `sdrf:` namespace (the two review-gate skills use po
 
 | Skill | What it does |
 |-------|-------------|
-| `/sdrf:setup` | Guided dependency install (parse_sdrf, techsdrf) — conda or pip |
-| `/sdrf:knowledge` | SDRF format, column rules, ontology mappings, reserved words; plain-language explanations; ontology term lookup |
-| `/sdrf:templates` | Template selection, layers, and selection rules |
-| `/sdrf:metascreen` | Shortlist PRIDE / MassIVE / ProteomeXchange studies → resumable TSV |
-| `/sdrf:autoresearch` | Autonomous retained-improvement loop over a dataset or dataset class |
-| `/sdrf:annotate` | Plan + full workflow: PXD → PRIDE + paper → draft SDRF → validate |
-| `/sdrf:validate` | Systematic validation against templates + OLS ontology checking |
-| `/sdrf:fix` | Auto-fix common errors (UNIMOD swaps, case, format, artifacts) |
-| `/sdrf:review` | Comprehensive quality review + 5-dimension quality score cross-referenced to paper + PRIDE |
+| `/sdrf-skills:sdrf-setup` | Guided dependency install (parse_sdrf, techsdrf) — conda or pip |
+| `/sdrf-skills:sdrf-knowledge` | SDRF format, column rules, ontology mappings, reserved words; plain-language explanations; ontology term lookup |
+| `/sdrf-skills:sdrf-templates` | Template selection, layers, and selection rules |
+| `/sdrf-skills:sdrf-metascreen` | Shortlist PRIDE / MassIVE / ProteomeXchange studies → resumable TSV |
+| `/sdrf-skills:sdrf-autoresearch` | Autonomous retained-improvement loop over a dataset or dataset class |
+| `/sdrf-skills:sdrf-annotate` | Plan + full workflow: PXD → PRIDE + paper → draft SDRF → validate |
+| `/sdrf-skills:sdrf-validate` | Systematic validation against templates + OLS ontology checking |
+| `/sdrf-skills:sdrf-fix` | Auto-fix common errors (UNIMOD swaps, case, format, artifacts) |
+| `/sdrf-skills:sdrf-review` | Comprehensive quality review + 5-dimension quality score cross-referenced to paper + PRIDE |
 | `$sdrf-adversarial-review` | Fresh-context, evidence-first review with a hash-bound verdict |
 | `$sdrf-annotate-reviewed` | Annotation orchestrator with isolated review, repair, and re-review |
-| `/sdrf:convert` | Choose and configure analysis pipelines from SDRF |
-| `/sdrf:design` | Detect batch effects, confounders, replication issues |
-| `/sdrf:contribute` | Contribute an annotated SDRF back to sdrf-annotated-datasets via PR |
-| `/sdrf:techrefine` | Verify/refine technical metadata from raw files via techsdrf |
-| `/sdrf:cellline` | Translate Cellosaurus records into SDRF cell-line columns |
+| `/sdrf-skills:sdrf-convert` | Choose and configure analysis pipelines from SDRF |
+| `/sdrf-skills:sdrf-design` | Detect batch effects, confounders, replication issues |
+| `/sdrf-skills:sdrf-contribute` | Contribute an annotated SDRF back to sdrf-annotated-datasets via PR |
+| `/sdrf-skills:sdrf-techrefine` | Verify/refine technical metadata from raw files via techsdrf |
+| `/sdrf-skills:sdrf-cellline` | Translate Cellosaurus records into SDRF cell-line columns |
 
 ## Installation
 
@@ -66,14 +66,14 @@ Update the bundled spec any time with `git submodule update --remote --recursive
 ```bash
 cd sdrf-skills && claude --plugin-dir .   # loads skills from the working tree
 ```
-Start from the repo root (skills reference `spec/` by repo-root-relative path). Then run `/sdrf:setup`, and use `/sdrf:annotate PXD######` or `/sdrf:validate your_file.sdrf.tsv`.
+Start from the repo root (skills reference `spec/` by repo-root-relative path). Then run `/sdrf-skills:sdrf-setup`, and use `/sdrf-skills:sdrf-annotate PXD######` or `/sdrf-skills:sdrf-validate your_file.sdrf.tsv`.
 
 **Marketplace install** (this repo is also a marketplace as of `.claude-plugin/marketplace.json`):
 ```bash
 /plugin marketplace add bigbio/sdrf-skills
 /plugin install sdrf-skills@sdrf-skills
 ```
-Caveat: several skills (e.g. `/sdrf:annotate`) reference `spec/` by a path relative to the repo root. A marketplace install copies the plugin into Claude Code's plugin cache, so those repo-root-relative reads may not resolve correctly there yet — the skills would need to resolve `spec/` via `${CLAUDE_PLUGIN_ROOT}` instead. Until that's done, prefer `--plugin-dir` for full functionality; the marketplace path is offered for discovery/installability, tracked further at [#27](https://github.com/bigbio/sdrf-skills/issues/27).
+Caveat: several skills (e.g. `/sdrf-skills:sdrf-annotate`) reference `spec/` by a path relative to the repo root. A marketplace install copies the plugin into Claude Code's plugin cache, so those repo-root-relative reads may not resolve correctly there yet — the skills would need to resolve `spec/` via `${CLAUDE_PLUGIN_ROOT}` instead. Until that's done, prefer `--plugin-dir` for full functionality; the marketplace path is offered for discovery/installability, tracked further at [#27](https://github.com/bigbio/sdrf-skills/issues/27).
 </details>
 
 <details><summary>Cursor</summary>
@@ -93,10 +93,10 @@ For full annotation, configure the **OLS**, **PRIDE**, **PubMed**, and **bioRxiv
 ## Usage
 
 ```text
-/sdrf:annotate PXD045678     → fetch PRIDE + paper → select templates → draft SDRF with OLS-verified terms → validate
-/sdrf:validate file.sdrf.tsv → template + ontology validation
-/sdrf:fix file.sdrf.tsv      → repair UNIMOD swaps, case, formats, artifacts (with changelog)
-/sdrf:contribute PXD045678   → open a PR to bigbio/sdrf-annotated-datasets
+/sdrf-skills:sdrf-annotate PXD045678     → fetch PRIDE + paper → select templates → draft SDRF with OLS-verified terms → validate
+/sdrf-skills:sdrf-validate file.sdrf.tsv → template + ontology validation
+/sdrf-skills:sdrf-fix file.sdrf.tsv      → repair UNIMOD swaps, case, formats, artifacts (with changelog)
+/sdrf-skills:sdrf-contribute PXD045678   → open a PR to bigbio/sdrf-annotated-datasets
 ```
 
 ## Python tools

--- a/criteria/single_cell_proteomics.md
+++ b/criteria/single_cell_proteomics.md
@@ -52,7 +52,7 @@ by evidence. Keep values short and analysis-ready.
 - `organism` — scientific name as reported (e.g. `Homo sapiens`, `Mus musculus`).
   Do NOT map to an NCBITaxon accession here; that happens during annotation.
 - `cell_type` — cell line or primary cell type (e.g. `HeLa`, `U-937`, `CD4+ T cell`).
-  Prefer the cell line name verbatim; `/sdrf:cellline` resolves Cellosaurus later.
+  Prefer the cell line name verbatim; `/sdrf-skills:sdrf-cellline` resolves Cellosaurus later.
 - `isolation_method` — how single cells were isolated (`CellenONE`, `FACS`,
   `nanoPOTS`, `laser capture`, `microfluidic`, `manual picking`).
 - `scp_method` — the named method/platform (`SCoPE2`, `plexDIA`, `nanoPOTS-DIA`, ...).

--- a/skills/sdrf-annotate/SKILL.md
+++ b/skills/sdrf-annotate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:annotate
+name: sdrf-annotate
 description: Use when the user wants to create or annotate an SDRF file for a proteomics dataset. Also use to plan what metadata to capture and discuss experimental design/strategy before creating the file. Triggers on PXD accessions, requests to create SDRF, planning/strategy questions, or annotation tasks.
 user-invocable: true
 argument-hint: "[PXD accession or experiment description]"
@@ -37,7 +37,7 @@ by an unrelated paper).
 
 Before starting, verify that `parse_sdrf` is available (run `parse_sdrf --version` or `which parse_sdrf`). If it is not installed:
 - Inform the user that programmatic validation will be skipped
-- Suggest `/sdrf:setup` or `conda env create -f environment.yml && conda activate sdrf-skills` (or `pip install -r requirements.txt`)
+- Suggest `/sdrf-skills:sdrf-setup` or `conda env create -f environment.yml && conda activate sdrf-skills` (or `pip install -r requirements.txt`)
 - Offer to continue with manual checks only, or wait for the user to install and retry
 
 ## Step 0.5: Check whether the dataset is ALREADY annotated — STOP GATE
@@ -75,7 +75,7 @@ Interpret the listing as an **artifact set**, not a yes/no:
   what your file should cover and how it should be named. Audit a sibling only if
   you intend to replace it.
 
-Use the same artifact set in `/sdrf:contribute` rather than recomputing it, so the
+Use the same artifact set in `/sdrf-skills:sdrf-contribute` rather than recomputing it, so the
 two workflows cannot disagree about what "already annotated" means.
 
 ### 0.5.2 Audit the existing annotation
@@ -540,12 +540,12 @@ Read TERMS.tsv `values` field for the column to determine which ontology(ies) to
 ### 4.5 Cell Line Lookup (if using cell-lines template)
 
 For any `characteristics[cell line]` column, prefer the dedicated
-`/sdrf:cellline` workflow or the live Cellosaurus service rather than a bundled
+`/sdrf-skills:sdrf-cellline` workflow or the live Cellosaurus service rather than a bundled
 full-database script. The skill owns the decision rules; tools are only helpers.
 
 Use this order:
 
-1. `/sdrf:cellline <name or CVCL_XXXX>` for the full translation workflow
+1. `/sdrf-skills:sdrf-cellline <name or CVCL_XXXX>` for the full translation workflow
 2. `python -m tools cellline lookup <name>` for the curated offline helper
 3. https://www.cellosaurus.org/search when you need manual confirmation
 
@@ -749,7 +749,7 @@ this column when the PRIDE term above applies.
 If the dataset has raw files available (PRIDE or local), recommend using **techsdrf**
 to verify and refine the technical metadata filled in Steps 5.1–5.5:
 ```text
-Run /sdrf:techrefine PXD###### to verify instrument, tolerances, modifications,
+Run /sdrf-skills:sdrf-techrefine PXD###### to verify instrument, tolerances, modifications,
 and DDA/DIA classification directly from the raw MS files.
 ```
 techsdrf can detect discrepancies between what's declared in the paper/PRIDE and
@@ -767,7 +767,7 @@ It reports the isolation windows, m/z coverage and CE ramp. Fill
 variable-width, the column is a single scalar, and deriving one from the manuscript
 ("15 windows spanning 400–1000" → 40) yields a width matching no actual window while
 passing both the regex and `parse_sdrf`. When the widths vary, the honest value is
-`not available` with the measured table in the report — see `/sdrf:techrefine`.
+`not available` with the measured table in the report — see `/sdrf-skills:sdrf-techrefine`.
 
 ## Step 6: Map Files to Samples
 
@@ -963,7 +963,7 @@ for ProteomeXchange datasets. Contributing your annotation means:
   - Analysis pipelines (quantms) can automatically reprocess the dataset
   - The annotation becomes part of the PRIDE SDRF Explorer
 
-Run /sdrf:contribute {PXD} to create a PR, or see the commands to do it manually.
+Run /sdrf-skills:sdrf-contribute {PXD} to create a PR, or see the commands to do it manually.
 ```
 
 3. If the PXD already existed, this is an **update**. The PR description must
@@ -1158,6 +1158,6 @@ Technical metadata (from instrument):
 
 Factor values: disease (tumor vs normal)
 
-Next step: Run /sdrf:annotate to create the file
+Next step: Run /sdrf-skills:sdrf-annotate to create the file
 ```
 

--- a/skills/sdrf-autoresearch/SKILL.md
+++ b/skills/sdrf-autoresearch/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:autoresearch
+name: sdrf-autoresearch
 description: Use when the user wants SDRF annotation to run as an autonomous retained-improvement loop over one dataset, a manifest, or a dataset class such as all PRIDE cell line or crosslinking datasets.
 user-invocable: true
 argument-hint: 'target="<dataset scope>" [profile="<preset>"] [objective="<metric>"] [focus_fields="<field1,field2>"] [evidence="<pride,files,europepmc>"] [stop="<rule>"] [write="<sandbox|branch|report-only>"]'
@@ -24,9 +24,9 @@ following the steps below and by calling the existing `sdrf:*` skills in order.
 
 Claude-style examples:
 ```text
-/sdrf:autoresearch target="all PRIDE cell line datasets"
-/sdrf:autoresearch target="all sandbox crosslinking datasets" profile="crosslinking"
-/sdrf:autoresearch target="manifest:data/cell_line_manifest.tsv" objective="maximize_valid_field_coverage"
+/sdrf-skills:sdrf-autoresearch target="all PRIDE cell line datasets"
+/sdrf-skills:sdrf-autoresearch target="all sandbox crosslinking datasets" profile="crosslinking"
+/sdrf-skills:sdrf-autoresearch target="manifest:data/cell_line_manifest.tsv" objective="maximize_valid_field_coverage"
 ```
 
 Codex-style examples:
@@ -276,27 +276,27 @@ For each dataset:
    Keep the accession in play and note the repository-backed limitation in the
    ranking output.
 
-2. Run `/sdrf:annotate`
+2. Run `/sdrf-skills:sdrf-annotate`
    - draft or extend the SDRF using the selected templates
 
-3. Run `/sdrf:knowledge`
+3. Run `/sdrf-skills:sdrf-knowledge`
    - normalize ontology-backed fields
    - use lexical OLS first
    - use embeddings for fuzzy manuscript-derived mentions
    - use ZOOMA as slower fallback when useful
 
-4. Run `/sdrf:techrefine`
+4. Run `/sdrf-skills:sdrf-techrefine`
    - refine technical MS metadata when raw files or techsdrf evidence are available
 
-5. Run `/sdrf:validate`
+5. Run `/sdrf-skills:sdrf-validate`
    - validate template structure, reserved words, and ontology-backed fields
    - keep validation concurrency bounded: default to serial, and never run more than `2` `parse_sdrf` jobs at once
    - if `sdrf-techrefine`, raw-file conversion, or other heavy analysis is active, validate only `1` dataset at a time
 
-6. Run `/sdrf:fix`
+6. Run `/sdrf-skills:sdrf-fix`
    - apply safe corrections to known SDRF error patterns
 
-7. Run `/sdrf:review`
+7. Run `/sdrf-skills:sdrf-review`
    - rescore completeness, specificity, consistency, standards, and design
 
 8. Keep or discard
@@ -379,15 +379,15 @@ If `write=report-only`, produce the same retained-improvement report without wri
 
 ### Cell lines
 ```text
-/sdrf:autoresearch target="all PRIDE cell line datasets" profile="cell-line" objective="maximize_valid_field_coverage" focus_fields="cell line,disease,organism part,treatment" evidence="pride,files,europepmc" stop="3_no_improve_rounds" write="sandbox"
+/sdrf-skills:sdrf-autoresearch target="all PRIDE cell line datasets" profile="cell-line" objective="maximize_valid_field_coverage" focus_fields="cell line,disease,organism part,treatment" evidence="pride,files,europepmc" stop="3_no_improve_rounds" write="sandbox"
 ```
 
 ### Crosslinking
 ```text
-/sdrf:autoresearch target="all sandbox crosslinking datasets" profile="crosslinking" objective="crosslinking_assay_completion" focus_fields="cross-linker,crosslink enrichment method,collision energy,crosslinking reaction time" evidence="pride,files,europepmc" stop="only_low_confidence_candidates_left" write="sandbox"
+/sdrf-skills:sdrf-autoresearch target="all sandbox crosslinking datasets" profile="crosslinking" objective="crosslinking_assay_completion" focus_fields="cross-linker,crosslink enrichment method,collision energy,crosslinking reaction time" evidence="pride,files,europepmc" stop="only_low_confidence_candidates_left" write="sandbox"
 ```
 
 ### Report-only review
 ```text
-/sdrf:autoresearch target="manifest:data/review_set.tsv" objective="minimize_unknowns" write="report-only"
+/sdrf-skills:sdrf-autoresearch target="manifest:data/review_set.tsv" objective="minimize_unknowns" write="report-only"
 ```

--- a/skills/sdrf-cellline/SKILL.md
+++ b/skills/sdrf-cellline/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:cellline
+name: sdrf-cellline
 description: Use when the user needs to look up cell line metadata or enrich an SDRF with cell-line-derived characteristics (organism, disease, sex, sampling site, ancestry, age). Triggers on cell line names (HeLa, MCF-7, A549, …), Cellosaurus accessions (CVCL_XXXX), or "annotate cell line" requests.
 user-invocable: true
 argument-hint: "[cell line name | CVCL_XXXX | path/to/file.sdrf.tsv]"
@@ -33,10 +33,10 @@ offline mode or needs to enrich many SDRFs in one pass.
   Cellosaurus-derivable columns (organism, disease, sampling site, sex,
   ancestry, age, developmental stage, cellosaurus accession/name) are blank,
   generic, or inconsistent.
-- Resolving ambiguous cell line names raised by `/sdrf:annotate`,
-  `/sdrf:validate`, or `/sdrf:fix`.
+- Resolving ambiguous cell line names raised by `/sdrf-skills:sdrf-annotate`,
+  `/sdrf-skills:sdrf-validate`, or `/sdrf-skills:sdrf-fix`.
 
-For pure ontology-term lookup unrelated to cell lines, use `/sdrf:knowledge`.
+For pure ontology-term lookup unrelated to cell lines, use `/sdrf-skills:sdrf-knowledge`.
 
 ## Step 0: Identify the cell-lines template requirements
 
@@ -73,7 +73,7 @@ The `cell-lines` template **also requires** an organism layer
 Cell line names in the wild are messy. Apply this pipeline before any lookup:
 
 1. **Strip enclosing punctuation/quotes/brackets.**
-   `"['HeLa']"` → `HeLa`. (The `/sdrf:fix` artifact rule handles this; rerun if dirty.)
+   `"['HeLa']"` → `HeLa`. (The `/sdrf-skills:sdrf-fix` artifact rule handles this; rerun if dirty.)
 2. **Trim whitespace** at both ends.
 3. **Recognize an accession directly.**
    Pattern `^CVCL_[A-Z0-9]{4,}$` → skip name lookup, fetch the accession.
@@ -153,7 +153,7 @@ When Step 2 yields more than one candidate, pick in this order:
    ambiguous queries: `293`, `SK`, `HCT`, `HEK`, `T-47`.
 
 If nothing matches:
-- Suggest the user check spelling, then offer `/sdrf:knowledge cell line "<name>"`
+- Suggest the user check spelling, then offer `/sdrf-skills:sdrf-knowledge cell line "<name>"`
   for a broader CLO/BTO/EFO search.
 - Set `characteristics[cell line]` to the user's input verbatim and the rest of
   the cell-line columns to `not available` (never `N/A`, never `unknown`).
@@ -252,7 +252,7 @@ The cell-lines template also defines `passage number`, `biorepository`,
 `cell line authentication`, `culture medium`, and `sample storage temperature`.
 Cellosaurus has no values for these — they are study-specific. Either:
 
-- Take them from the paper / PRIDE submission via `/sdrf:annotate`, or
+- Take them from the paper / PRIDE submission via `/sdrf-skills:sdrf-annotate`, or
 - Set them to `not available` if the paper does not state them.
 
 ## Step 5: Bulk enrichment of an SDRF
@@ -266,7 +266,7 @@ When the input is a `.sdrf.tsv` file:
 4. For each row, fill empty / `not available` Cellosaurus-derivable columns.
    **Do not overwrite** existing values that disagree with Cellosaurus —
    instead, surface them as conflicts and ask the user, exactly the way
-   `/sdrf:review` does.
+   `/sdrf-skills:sdrf-review` does.
 5. If the SDRF lacks a needed column entirely (e.g.
    `characteristics[cellosaurus accession]`), insert it adjacent to
    `characteristics[cell line]` and re-emit the full TSV.
@@ -293,7 +293,7 @@ parse_sdrf validate-sdrf \
   --template cell-lines
 ```
 
-Then run `/sdrf:validate` for ontology-level checks. Round-trip rules:
+Then run `/sdrf-skills:sdrf-validate` for ontology-level checks. Round-trip rules:
 
 - `CVCL_*` accessions must resolve via the Cellosaurus REST API
   (`/cell-line/<CVCL_id>`).

--- a/skills/sdrf-contribute/SKILL.md
+++ b/skills/sdrf-contribute/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:contribute
+name: sdrf-contribute
 description: Use when the user has a completed SDRF annotation for a ProteomeXchange dataset and wants to contribute it back to the community via a PR to sdrf-annotated-datasets.
 user-invocable: true
 argument-hint: "[PXD accession and SDRF file path]"
@@ -19,7 +19,7 @@ and review — closing the loop from "I annotated a dataset" to "the community c
 
 ### 1.2 Verify the SDRF content
 - The SDRF must be available as a file on disk or from a previous annotation step
-- If the user just finished `/sdrf:annotate`, the content is in the conversation
+- If the user just finished `/sdrf-skills:sdrf-annotate`, the content is in the conversation
 - Ask the user to confirm the file path or provide the content
 
 ### 1.3 Check if this is a new annotation or an update
@@ -76,7 +76,7 @@ Then:
   each defect, the evidence from the deposit, and what the new file does instead.
   A reviewer must be able to check the claim rather than trust it.
 
-If `/sdrf:annotate` already ran its Step 0.5 gate for this accession, reuse that
+If `/sdrf-skills:sdrf-annotate` already ran its Step 0.5 gate for this accession, reuse that
 audit instead of repeating it, and confirm the user chose `fix` or `reannotate`.
 **Never open a PR that silently overwrites an existing annotation.**
 
@@ -94,7 +94,7 @@ Before contributing, the SDRF must pass validation:
 
    **Zero-deletion guard (mandatory before PR):** stage only your new folder (`git add datasets/{PXD}/`, never `git add -A`), then run `git diff --cached --name-status` and confirm every line is `A` — abort if any `D`/`M`/`R` touches a dataset you did not create.
 
-2. **Run `/sdrf:validate`** for a thorough check including ontology verification
+2. **Run `/sdrf-skills:sdrf-validate`** for a thorough check including ontology verification
 
 3. **Require independent adversarial approval**:
    ```bash
@@ -244,7 +244,7 @@ After the PR is created:
 
 - NEVER create a PR without user confirmation
 - NEVER skip validation before contributing
-- NEVER modify the SDRF content during the contribution step (that's what `/sdrf:fix` and `/sdrf:review` are for)
+- NEVER modify the SDRF content during the contribution step (that's what `/sdrf-skills:sdrf-fix` and `/sdrf-skills:sdrf-review` are for)
 - If the user doesn't have `gh` CLI installed, always fall back to Mode B (guided commands)
 - If the user doesn't have a GitHub account, explain that one is needed and point to https://github.com/signup
 - For non-PXD accessions (MSV, PMID), the same workflow applies — just use the accession as the folder name

--- a/skills/sdrf-convert/SKILL.md
+++ b/skills/sdrf-convert/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:convert
+name: sdrf-convert
 description: Use when the user wants to choose an analysis pipeline, check SDRF compatibility with a pipeline, or understand how to go from SDRF to analysis.
 user-invocable: true
 argument-hint: "[pipeline name or experiment description]"

--- a/skills/sdrf-design/SKILL.md
+++ b/skills/sdrf-design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:design
+name: sdrf-design
 description: Use when the user wants to analyze the experimental design encoded in an SDRF file, check for batch effects, confounders, or replication issues.
 user-invocable: true
 argument-hint: "[file path or paste SDRF content]"

--- a/skills/sdrf-fix/SKILL.md
+++ b/skills/sdrf-fix/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:fix
+name: sdrf-fix
 description: Use when the user has an SDRF file with known errors and wants them fixed automatically. Triggers on requests to fix, correct, or repair SDRF errors.
 user-invocable: true
 argument-hint: "[file path or paste SDRF content]"
@@ -13,7 +13,7 @@ You are fixing known common errors in an SDRF file. Apply fixes systematically.
 
 Verify that `parse_sdrf` is available (run `parse_sdrf --version` or `which parse_sdrf`). If it is not installed:
 - Inform the user that re-validation after fixes will need to be done manually
-- Suggest `/sdrf:setup` or `conda env create -f environment.yml && conda activate sdrf-skills` (or `pip install -r requirements.txt`)
+- Suggest `/sdrf-skills:sdrf-setup` or `conda env create -f environment.yml && conda activate sdrf-skills` (or `pip install -r requirements.txt`)
 - Continue with the fixes; the user can validate later once dependencies are installed
 
 ## Common Error Patterns and Their Fixes
@@ -203,7 +203,7 @@ If `parse_sdrf` is not installed, tell the user: `pip install sdrf-pipelines`
 Present the re-validation summary alongside the changelog.
 
 If all errors are fixed and the SDRF is for a ProteomeXchange dataset (PXD accession),
-suggest contributing the corrected annotation via `/sdrf:contribute {PXD}` to the
+suggest contributing the corrected annotation via `/sdrf-skills:sdrf-contribute {PXD}` to the
 `sdrf-annotated-datasets` community repository.
 
 ## When NOT to Auto-Fix

--- a/skills/sdrf-knowledge/SKILL.md
+++ b/skills/sdrf-knowledge/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:knowledge
+name: sdrf-knowledge
 description: Use when the user asks about the SDRF format, column naming rules, ontology mappings, modification format, reserved words, label types, or any SDRF specification question, wants a plain-language explanation of a column/error/concept, or needs to find/verify/compare ontology terms and accessions for a column. Also serves as background knowledge for all other SDRF skills.
 user-invocable: true
 argument-hint: "[question about SDRF format or column rules]"
@@ -371,7 +371,7 @@ Experiment (optional), Clinical (optional), and Metaproteomics (special).
 You declare templates via `comment[sdrf template]` columns:
   `NT=ms-proteomics;VV=v1.1.0`
 
-See `/sdrf:templates` for the full selection guide and decision tree.
+See `/sdrf-skills:sdrf-templates` for the full selection guide and decision tree.
 
 ### "How many rows should my SDRF have?"
 ```text

--- a/skills/sdrf-metascreen/SKILL.md
+++ b/skills/sdrf-metascreen/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:metascreen
+name: sdrf-metascreen
 description: Use when the user needs to screen or shortlist proteomics studies from PRIDE, MassIVE, or ProteomeXchange accessions, or from a manifest, using detailed user-defined inclusion/exclusion criteria — run this before sdrf:autoresearch; extract study-level metadata from repository records and publications; and write an evidence-backed, resumable TSV for downstream annotation, review, or meta-analysis.
 user-invocable: true
 argument-hint: 'target="<all PRIDE|MassIVE ...|accessions:PXD...,MSV...|path/to/accessions.txt|path/to/manifest.tsv>" [criteria="<md|txt|inline>"] [extract="<cols|txt|md>"] [output="results.tsv"] [dig_passes=1]'
@@ -458,16 +458,16 @@ each, so a human knows what to go find.
 
 ```text
 # Discover across PRIDE + MassIVE and screen
-/sdrf:metascreen target="all PRIDE human gut metaproteomics datasets" criteria="criteria/human_gut_metaproteomics.md" extract="criteria/human_gut_metaproteomics.md" output="results/human_gut_screen.tsv"
+/sdrf-skills:sdrf-metascreen target="all PRIDE human gut metaproteomics datasets" criteria="criteria/human_gut_metaproteomics.md" extract="criteria/human_gut_metaproteomics.md" output="results/human_gut_screen.tsv"
 
 # Fixed accession list from a txt file
-/sdrf:metascreen target="data/accessions.txt" criteria="criteria/eligibility.md" extract="instrument,acquisition,sex,age,region" output="results/screen.tsv"
+/sdrf-skills:sdrf-metascreen target="data/accessions.txt" criteria="criteria/eligibility.md" extract="instrument,acquisition,sex,age,region" output="results/screen.tsv"
 
 # Mixed PRIDE + MassIVE accessions
-/sdrf:metascreen target="accessions:PXD005969,MSV000078958" criteria="human fecal metaproteomics only; exclude animal-only studies" extract="organism,sample_type,instrument" output="results/screen.tsv"
+/sdrf-skills:sdrf-metascreen target="accessions:PXD005969,MSV000078958" criteria="human fecal metaproteomics only; exclude animal-only studies" extract="organism,sample_type,instrument" output="results/screen.tsv"
 
 # From a manifest TSV
-/sdrf:metascreen target="data/candidates.tsv" criteria="criteria/eligibility.md" extract="criteria/extract_fields.txt" output="results/screen.tsv"
+/sdrf-skills:sdrf-metascreen target="data/candidates.tsv" criteria="criteria/eligibility.md" extract="criteria/extract_fields.txt" output="results/screen.tsv"
 ```
 
 ## Notes

--- a/skills/sdrf-review/SKILL.md
+++ b/skills/sdrf-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:review
+name: sdrf-review
 description: Use when the user wants a comprehensive quality review of an SDRF file, a PR review of an SDRF submission, a quality score assessment, or to improve/score an existing SDRF strictly against templates and specification rules (specificity, completeness, consistency; no speculative additions).
 user-invocable: true
 argument-hint: "[file path, PXD accession, or GitHub PR URL]"
@@ -53,7 +53,7 @@ DISCREPANCY: Paper mentions "hippocampus and temporal cortex" but SDRF only has 
 ```
 
 For technical metadata (instrument, tolerances, modifications, DDA/DIA), consider
-recommending `/sdrf:techrefine` — techsdrf can verify these parameters directly from
+recommending `/sdrf-skills:sdrf-techrefine` — techsdrf can verify these parameters directly from
 the raw MS files, which is more reliable than cross-referencing with the publication.
 
 ### Conflict Resolution
@@ -147,11 +147,11 @@ Calculate and present an overall quality score:
 
 Provide clear next steps:
 1. List fixes in priority order
-2. Offer to auto-fix what can be auto-fixed (`/sdrf:fix`)
+2. Offer to auto-fix what can be auto-fixed (`/sdrf-skills:sdrf-fix`)
 3. Identify what needs human input (e.g., missing demographics)
 4. Suggest running final validation after fixes
 5. If the SDRF is for a ProteomeXchange dataset and the verdict is VALID or NEEDS MINOR FIXES:
-   suggest contributing the annotation via `/sdrf:contribute {PXD}` to the
+   suggest contributing the annotation via `/sdrf-skills:sdrf-contribute {PXD}` to the
    `sdrf-annotated-datasets` community repository
 
 ---

--- a/skills/sdrf-setup/SKILL.md
+++ b/skills/sdrf-setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:setup
+name: sdrf-setup
 description: Use when the user wants to set up SDRF skills dependencies, install parse_sdrf and techsdrf, or configure the environment for the first time.
 user-invocable: true
 argument-hint: "[optional: conda | pip | check]"
@@ -9,7 +9,7 @@ argument-hint: "[optional: conda | pip | check]"
 
 You are guiding the user through installing SDRF skills dependencies. Follow these steps.
 
-**In Cursor**: The user invokes this by asking "install SDRF dependencies" or similar (no `/sdrf:setup` slash command). Ensure `environment.yml` and `requirements.txt` exist at the workspace root; if not, suggest cloning the full sdrf-skills repo or copying those files.
+**In Cursor**: The user invokes this by asking "install SDRF dependencies" or similar (no `/sdrf-skills:sdrf-setup` slash command). Ensure `environment.yml` and `requirements.txt` exist at the workspace root; if not, suggest cloning the full sdrf-skills repo or copying those files.
 
 ## Step 1: Detect Available Package Managers
 
@@ -105,11 +105,11 @@ Provide a clear summary:
 1. **Package manager detected**: conda / pip / uv
 2. **Commands to run**: (copy-paste block)
 3. **Verify**: parse_sdrf --version, techsdrf --version
-4. **Next**: Run /sdrf:annotate PXD###### or /sdrf:validate yourfile.sdrf.tsv
+4. **Next**: Run /sdrf-skills:sdrf-annotate PXD###### or /sdrf-skills:sdrf-validate yourfile.sdrf.tsv
 
 ## If User Passes "check"
 
-When the user invokes `/sdrf:setup check`, run the verification step and report status:
+When the user invokes `/sdrf-skills:sdrf-setup check`, run the verification step and report status:
 - parse_sdrf: ✓ or ✗
 - techsdrf: ✓ or ✗
 - spec/ submodule: present and init'd or not

--- a/skills/sdrf-techrefine/SKILL.md
+++ b/skills/sdrf-techrefine/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:techrefine
+name: sdrf-techrefine
 description: Use when the user wants to refine or verify SDRF technical metadata (instrument, tolerances, modifications, DDA/DIA) using raw MS file analysis via techsdrf.
 user-invocable: true
 argument-hint: "[PXD accession or SDRF file path]"
@@ -214,7 +214,7 @@ For each changed column:
 - Explain WHY techsdrf made this change (what evidence from raw data)
 - Let the user approve or reject the individual change
 
-### 6.3 If the user is working on an in-memory SDRF from `/sdrf:annotate`
+### 6.3 If the user is working on an in-memory SDRF from `/sdrf-skills:sdrf-annotate`
 Instead of a file diff, show the corrected values to paste into the SDRF:
 ```text
 Update these technical columns based on raw file analysis:
@@ -255,7 +255,7 @@ until validation passes (or only warnings remain).
 If this is a ProteomeXchange dataset:
 ```text
 Your refined SDRF has verified technical metadata from actual raw file analysis.
-Run /sdrf:contribute to submit this annotation to the community repository.
+Run /sdrf-skills:sdrf-contribute to submit this annotation to the community repository.
 ```
 
 ## Bruker timsTOF: DIA windows straight from `analysis.tdf`

--- a/skills/sdrf-templates/SKILL.md
+++ b/skills/sdrf-templates/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:templates
+name: sdrf-templates
 description: Use when the user asks about SDRF templates, wants to select templates for an experiment, or needs to understand template layers, inheritance, mutual exclusivity, and selection rules.
 user-invocable: true
 argument-hint: "[experiment description or template name]"

--- a/skills/sdrf-validate/SKILL.md
+++ b/skills/sdrf-validate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: sdrf:validate
+name: sdrf-validate
 description: Use when the user wants to validate an SDRF file, check for errors, or verify ontology terms. Triggers on requests to check, validate, or review SDRF content.
 user-invocable: true
 argument-hint: "[file path or paste SDRF content]"
@@ -13,7 +13,7 @@ You are validating an SDRF file. Perform systematic checks in order.
 
 Verify that `parse_sdrf` is available (run `parse_sdrf --version` or `which parse_sdrf`). If it is not installed:
 - Inform the user that programmatic validation with parse_sdrf will be skipped
-- Suggest `/sdrf:setup` or `conda env create -f environment.yml && conda activate sdrf-skills` (or `pip install -r requirements.txt`)
+- Suggest `/sdrf-skills:sdrf-setup` or `conda env create -f environment.yml && conda activate sdrf-skills` (or `pip install -r requirements.txt`)
 - Continue with structural and ontology checks; manual validation is still valuable
 
 ## Step 0.5: Protect the Machine During Validation


### PR DESCRIPTION
## Summary

Every skill's own `name:` frontmatter, the README's command table, `CLAUDE.md`'s authoring template, and every skill's cross-references to other skills document invocation as `/sdrf:annotate`, `/sdrf:validate`, etc. That address has never worked once this repo is installed as a marketplace plugin (following #74): Claude Code derives a skill's slash address from `<plugin-name>:<skill-directory-name>`, not from the arbitrary `name:` string a skill author writes. This plugin's own name (`.claude-plugin/plugin.json`) is `sdrf-skills`, so the real, working address is `/sdrf-skills:sdrf-annotate`, `/sdrf-skills:sdrf-validate`, and so on.

Verified directly in a real Claude Code session with the plugin installed via the marketplace: every skill is listed as `sdrf-skills:sdrf-*`, never bare `sdrf:*`.

## What changed

- Every domain skill's `name:` frontmatter: `sdrf:<x>` → `sdrf-<x>` (matches its own directory). The two review-gate skills (`sdrf-adversarial-review`, `sdrf-annotate-reviewed`) were already correct and are untouched.
- `CLAUDE.md`'s frontmatter-schema template — this is the actual root cause of the drift, not just a stray doc bug: it explicitly instructed future contributors to write the broken form, with a comment acknowledging "does NOT match the directory" instead of flagging it as wrong.
- Every `/sdrf:<x>` reference across `README.md`, `CLAUDE.md`, and all `SKILL.md` bodies' cross-references to other skills, updated to `/sdrf-skills:sdrf-<x>`.

## Not in scope

- The `$sdrf-adversarial-review` / `$sdrf-annotate-reviewed` references — these intentionally use a different, platform-portable convention per `CLAUDE.md`'s own design notes, left untouched.
- The separate `spec/` repo-root-relative path issue already tracked on #27 — a functional fix (resolving via `${CLAUDE_PLUGIN_ROOT}`), not a naming one.

## Test plan

- [x] `git diff --stat` confirms only documentation files changed (17 `.md` files, no code)
- [x] `grep -rn "/sdrf:[a-z]"` across the repo returns nothing after the fix
- [x] Cross-checked against a real installed session: skills list as `sdrf-skills:sdrf-*`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill names and command examples to use the new hyphenated naming convention.
  * Updated setup instructions, cross-references, frontmatter examples, and screening guidance to use the `/sdrf-skills:sdrf-*` command format.
  * Clarified usage across all documented SDRF skills without changing their workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->